### PR TITLE
Fix the documentation deployment workflow path

### DIFF
--- a/.changeset/docs-deploy-repair-1775756676.md
+++ b/.changeset/docs-deploy-repair-1775756676.md
@@ -1,0 +1,12 @@
+---
+"skill-harbor": patch
+---
+
+<!-- hero: The Chart Room Corrected -->
+
+The docs deployment route was steering Vercel into the wrong berth. This patch corrects the GitHub Actions workflow so the documentation build uses the project's configured root directory instead of doubling the `apps/manual` path, and it renames the deployment task to better reflect its real purpose.
+
+## 🛠️ Barnacle Scraping
+
+- Fixed `.github/workflows/deploy-docs.yml` by removing the extra `working-directory` overrides from the Vercel pull/build/deploy steps so the workflow no longer resolves `apps/manual/apps/manual/package.json`.
+- Renamed the workflow job from `Deploy-Production` to `Deploy Documentation` for clearer GitHub Actions status output.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,8 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 jobs:
-  Deploy-Production:
+  deploy-documentation:
+    name: Deploy Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,18 +35,15 @@ jobs:
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
-        working-directory: ./apps/manual
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
         run: vercel build --prod --token=$VERCEL_TOKEN
-        working-directory: ./apps/manual
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN
-        working-directory: ./apps/manual
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
Fix the documentation deployment workflow so Vercel builds from the repository root instead of accidentally resolving `apps/manual` twice.

## Problem
The linked Vercel project already declares `apps/manual` as its `rootDirectory`. The GitHub Actions workflow was also running `vercel pull`, `vercel build`, and `vercel deploy` from `working-directory: ./apps/manual`.

That caused Vercel to look for:

- `apps/manual/apps/manual/package.json`

which matches the failing GitHub Actions error:

> ENOENT: no such file or directory, open '/home/runner/work/skill-harbor/skill-harbor/apps/manual/apps/manual/package.json'

## What changed
- removed the extra `working-directory: ./apps/manual` overrides from the Vercel CLI steps in `.github/workflows/deploy-docs.yml`
- renamed the workflow job from `Deploy-Production` to `Deploy Documentation`
- added a patch changeset describing the deployment repair

## Why this should work
With the workflow now running from repo root, Vercel can use the project's configured `rootDirectory` normally instead of effectively applying `apps/manual` twice.

## Verification
- parsed `.github/workflows/deploy-docs.yml` successfully with Ruby YAML
- reviewed the workflow diff against the reported failing path symptom

## Notes
- This PR is intentionally scoped to the docs deployment workflow only.
- Live GitHub Actions / Vercel execution was not run from this environment.
