### PR TITLE
Stabilize concurrent sync terminal output

### DIFF
--- a/.changeset/issue-4-terminal-ux-1775786881.md
+++ b/.changeset/issue-4-terminal-ux-1775786881.md
@@ -1,0 +1,12 @@
+---
+"skill-harbor": patch
+---
+
+<!-- hero: Calm Seas for Concurrent Sync -->
+
+The fleet no longer tries to animate its way through parallel sync work. This patch switches concurrent workspace synchronization to deterministic spinner output so mixed success, skip, cache-reuse, and failure states stay readable without fragile multi-spinner animation.
+
+## 🛠️ Barnacle Scraping
+
+- Updated `apps/cli/src/commands/up.ts` to create `Spinnies` with `disableSpins: true` for the concurrent sync path, trading animation for clearer, more stable terminal output.
+- Added regression coverage in `apps/cli/src/commands/up.test.ts` to ensure the concurrent sync flow keeps spinner animation disabled.

--- a/.changeset/quartermaster-mnxf95cf.md
+++ b/.changeset/quartermaster-mnxf95cf.md
@@ -1,0 +1,18 @@
+---
+"skill-harbor": minor
+---
+
+<!-- hero: Charting Clearer Waters -->
+
+Captain's Briefing: The harbor's charts are sharper and the rigging is tighter. This release adds stronger Voyager tooling, manual clarifications for a similiar project, and explanations for product boundaries.
+## ✨ New Cargo 
+- **Voyager Comparison Mode**: Added `skill-harbor voyager --compare` to assess skill impact on agent performance, now found in `apps/cli/src/index.ts` and `apps/cli/src/commands/voyager.ts`. 
+- **Structured Voyager Results**: Introduced result models in `apps/cli/src/types/voyager.ts` for better comparison and analysis. 
+- **Dedicated Manual Documentation App**: Launched `apps/manual`, a Next.js site for our manual, enhancing navigation, search, and documentation structure. 
+## 🛡️ Hardened Hull 
+- **Monorepo Verification**: Updated `turbo.json` to include the `test` task, ensuring `bun run test` covers the entire workspace. 
+- **CI/CD Enhancements**: Adjusted GitHub Actions for monorepo support and dedicated manual deployment. 
+## 🛠️ Barnacle Scraping 
+- **Refactored Voyager Command**: Broken down `apps/cli/src/commands/voyager.ts` into smaller helpers for easier maintenance and future additions. 
+- **Improved Cache Handling**: Enhanced manifest and cache handling in `apps/cli/src/manifest.ts` to prevent global and project cache mix-ups. 
+- **Version Alignment**: Ensured `skill-harbor --version` reflects the package version in `apps/cli/package.json`, now covered by integration tests.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -24,7 +24,7 @@
     "build": "mkdir -p dist && bun build ./src/index.ts --target node --outfile dist/index.js --external commander --external kleur --external spinnies --external ora --external fast-glob --external boxen",
     "version": "changeset version",
     "release": "npm run build && changeset publish",
-    "quartermaster": "bun ./scripts/quartermaster.ts",
+    "quartermaster": "bun ../../scripts/quartermaster.ts",
     "lint": "oxlint src"
   },
   "dependencies": {

--- a/apps/cli/src/commands/up.test.ts
+++ b/apps/cli/src/commands/up.test.ts
@@ -6,13 +6,27 @@ import { printHeader, printSuccess, printError, promptEmptyProjectHarborAction, 
 import fs from 'node:fs/promises';
 import os from 'node:os';
 
+const spinniesCtor = vi.fn();
+
 vi.mock('../orchestrator');
 vi.mock('../utils');
 vi.mock('../ui');
 vi.mock('node:fs/promises');
 vi.mock('node:fs');
 vi.mock('node:os');
-vi.mock('spinnies');
+vi.mock('spinnies', () => ({
+    default: class MockSpinnies {
+        constructor(...args: any[]) {
+            spinniesCtor(...args);
+        }
+        add = vi.fn();
+        update = vi.fn();
+        succeed = vi.fn();
+        fail = vi.fn();
+        remove = vi.fn();
+        pick = vi.fn();
+    }
+}));
 vi.mock('fast-glob');
 vi.mock('node:child_process', () => ({
     exec: vi.fn(),
@@ -97,6 +111,17 @@ describe('upAction', () => {
         expect(mockOrchestrator.berth).toHaveBeenCalled();
         expect(mockManifestManager.addSkill).toHaveBeenCalled();
         expect(printSuccess).toHaveBeenCalledWith(expect.stringContaining('Workspace Sync complete.'));
+    });
+
+    it('should disable spinner animation for concurrent sync output', async () => {
+        const options = {};
+        const mockCommand = {
+            opts: vi.fn().mockReturnValue(options),
+        };
+
+        await upAction(options, mockCommand);
+
+        expect(spinniesCtor).toHaveBeenCalledWith({ disableSpins: true });
     });
 
     it('should skip sync if no changes are detected', async () => {

--- a/apps/cli/src/commands/up.ts
+++ b/apps/cli/src/commands/up.ts
@@ -148,7 +148,9 @@ function parseTargetOption(targetOption?: string | string[]): string[] | undefin
 export async function upAction(options: any, command: any) {
     const opts = command.opts();
     const manifestManager = getManifestManager(opts);
-    const spinnies = new Spinnies();
+    // Concurrent sync is easier to read as deterministic line updates than as
+    // animated multi-spinner rendering, especially in mixed success/failure runs.
+    const spinnies = new Spinnies({ disableSpins: true });
 
     try {
         printHeader("Workspace Synchronization Initiated");

--- a/docs/faq/agent-skill-harbor.mdx
+++ b/docs/faq/agent-skill-harbor.mdx
@@ -1,0 +1,240 @@
+---
+title: "Why Not Agent Skill Harbor?"
+description: "How Skill Harbor differs from Agent Skill Harbor, where they overlap, and when it makes sense to use both"
+icon: "anchor"
+---
+
+# Why Not Agent Skill Harbor?
+
+This question comes up because both projects use the word **Harbor**, both are about **agent skills**, and both help teams standardize AI context. The short answer is:
+
+> **Agent Skill Harbor is primarily a catalog and governance layer. Skill Harbor is primarily a sync, conversion, and runtime delivery layer.**
+
+They overlap, but they are not the same product.
+
+> **Positioning answer:** If someone asks *"Why not just use Agent Skill Harbor?"*, the cleanest answer is: **because a catalog is not the same thing as a deployment engine**. Agent Skill Harbor helps teams organize and govern skills across repositories. Skill Harbor helps teams actually fetch, convert, berth, isolate, and restore those skills in live agent runtimes.
+
+---
+
+## The shortest answer
+
+If your question is:
+
+- *"How do we collect, review, classify, and publish skills across a team or org?"* → **Agent Skill Harbor** is aimed more directly at that problem.
+- *"How do we make sure the right skills actually land in Claude, Cursor, Codex, Gemini, Continue, Windsurf, Copilot, or Rulesync on developer machines?"* → **Skill Harbor** is aimed more directly at that problem.
+
+A useful mental model is:
+
+- **Agent Skill Harbor** = **catalog / governance / marketplace**
+- **Skill Harbor** = **delivery engine / orchestrator / berth manager**
+
+---
+
+## Quick comparison
+
+| Area | Agent Skill Harbor | Skill Harbor |
+| --- | --- | --- |
+| Primary role | Catalog and governance layer | Sync and runtime delivery layer |
+| Main operating model | Separate control-plane repo for collecting and publishing skills | Repo-adjacent manifests plus live target synchronization |
+| Best for | Org-wide discovery, provenance, approval, publication | Installing the right skills into real agent targets |
+| Works across many repos | Yes, as a catalog/control plane | Yes, via manifests and global fleet sync |
+| Lives alongside a working repo | Not as its main identity | Yes, explicitly |
+| Converts skills for targets | Not its primary value proposition | Yes |
+| Manages live root skill folders | Not as its primary surface | Yes |
+| Cleanup / restore operations | Not clearly a first-class workflow | Yes: `stow`, `unstow`, `undock`, `--lockdown` |
+
+---
+
+## When should I use which?
+
+Use **Agent Skill Harbor** when your main need is:
+
+- building a browsable internal skill catalog
+- collecting skills from many repositories
+- tracking provenance, approval, and publication
+- managing skill discovery at the organization level
+
+Use **Skill Harbor** when your main need is:
+
+- declaring the skill fleet a repo should use
+- syncing skills into real agent runtimes
+- converting skills for different targets
+- isolating workspace state with manifests and lockdown
+- cleaning up, restoring, or auditing installed skill folders
+
+Use **both** when you want:
+
+- a central system of record for what is approved
+- plus a deterministic way to install that approved fleet into live developer environments
+
+---
+
+## Where they overlap
+
+Both projects help with:
+
+- organizing agent skills for teams
+- sharing skills through Git and repository workflows
+- improving consistency across developers
+- making governance and standardization more explicit
+
+If all you need is a broad answer to *"Do these repos live in the same space?"* the answer is **yes**.
+
+---
+
+## Where Skill Harbor is different
+
+Skill Harbor is built around the operational workflow of:
+
+1. **declaring skills in a manifest**
+2. **fetching them into harbor-controlled staging**
+3. **processing or converting them for the target runtime**
+4. **berthing them into real agent directories**
+5. **checking, stowing, restoring, and governing that installed state**
+
+That is why the center of Skill Harbor is commands like:
+
+- `dock`
+- `up`
+- `check`
+- `fathom`
+- `stow`
+- `unstow`
+- `undock`
+
+This is a strong fit when you care about:
+
+- deterministic rollout into live agent environments
+- one-command workspace synchronization
+- multi-target delivery
+- target-aware conversion between agent ecosystems
+- local, project, and global harbor layering
+- install-time governance and workspace isolation
+
+---
+
+## Where Agent Skill Harbor appears stronger
+
+At a high level, Agent Skill Harbor appears more focused on:
+
+- cataloging skills across repositories
+- provenance and publication
+- approval/governance workflows
+- organization-level browsing and discovery
+- marketplace-style visibility into what skills exist
+
+That is a different value proposition from *"take this declared fleet and install it into my actual agent berths."*
+
+---
+
+## Why not just use Agent Skill Harbor?
+
+Because a **catalog** is not the same thing as a **deployment engine**.
+
+Knowing that a skill exists, is approved, or is recommended is valuable. But a team still has to answer questions like:
+
+- How does that skill get onto a developer's machine?
+- How does it get transformed for Claude vs. Gemini vs. Codex?
+- How do we keep project-specific skills from bleeding across client workspaces?
+- How do we detect missing berths or drift in installed state?
+- How do we restore or lock down the environment safely?
+
+Those are the kinds of problems Skill Harbor is designed to solve directly.
+
+---
+
+## Can both make sense together?
+
+Yes — and this is often the best way to think about them.
+
+A practical split is:
+
+- use **Agent Skill Harbor** as the **system of record** for cataloging, provenance, review, and approval
+- use **Skill Harbor** as the **runtime delivery engine** that syncs the approved fleet into actual agent targets
+
+In that model, the two projects are **complementary** rather than redundant.
+
+---
+
+## Do both help manage or clean up user root skills?
+
+Not in the same way.
+
+### Skill Harbor: yes, explicitly
+
+Skill Harbor directly manages the **installed state** in real agent roots and project berths.
+
+That includes things like:
+
+- a project manifest at `.harbor/harbor-manifest.json`
+- a global manifest at `~/.harbor/harbor-manifest.json`
+- syncing into active agent targets with `up`
+- cleaning and restoring state with `stow`, `unstow`, and `undock`
+- isolating sensitive workspaces with `up --lockdown`
+
+So if your question is *"Can this tool help me control what is actually sitting in `.claude/skills`, `.agents/skills`, or similar folders?"* the answer for Skill Harbor is **yes**.
+
+### Agent Skill Harbor: not as its primary surface
+
+Agent Skill Harbor appears stronger as a **catalog, provenance, and governance layer** than as a direct manager of live root skill folders.
+
+From its public documentation, it clearly supports:
+
+- collection
+- cataloging
+- governance labels
+- post-collect analysis plugins
+- drift-oriented auditing in the catalog pipeline
+
+But it does **not** present itself primarily as a tool for:
+
+- stowing and restoring local root skills
+- purging live agent berths
+- managing installed skills directly inside local runtime folders
+
+So the practical distinction is:
+
+> **Skill Harbor manages live installed skill state. Agent Skill Harbor manages catalog and governance state.**
+
+---
+
+## Which one is more mature?
+
+That depends on **which layer** you mean.
+
+- If you mean **catalog, governance, and publication UX**, Agent Skill Harbor may be the more natural comparison point.
+- If you mean **multi-target sync, target conversion, and live workspace delivery**, Skill Harbor is solving a more specific operational problem.
+
+So the better question is usually not *"Which one wins?"* but *"Which layer of the workflow do we need to own?"*
+
+---
+
+## Another important comparison area
+
+One of the most important comparison areas is **install-time policy enforcement**.
+
+Not just:
+
+- *Can we mark skills as approved or discouraged?*
+
+But also:
+
+- *Can we prevent prohibited skills from being installed?*
+- *Can we detect drift between approved state and installed state?*
+- *Can we revoke or replace installed skills reliably?*
+
+That is where catalog tooling and delivery tooling usually diverge the most.
+
+---
+
+## Bottom line
+
+If someone says **"Why not just use Agent Skill Harbor?"**, the most accurate short answer is:
+
+> Because Agent Skill Harbor helps you manage and publish a skill catalog, while Skill Harbor helps you actually sync, convert, berth, and govern those skills in live agent runtimes.
+
+Use **Agent Skill Harbor** when your primary problem is **cataloging and governance**.
+
+Use **Skill Harbor** when your primary problem is **operational rollout into real agent targets**.
+
+Use **both** when you want a catalog **and** a deterministic delivery path.

--- a/docs/faq/comparison.mdx
+++ b/docs/faq/comparison.mdx
@@ -30,6 +30,8 @@ While both tools deal with "Agent Skills," their core purposes, target audiences
 *   **How it works**: A repository maintains a declarative `harbor-manifest.json`. Developers run a single `skill-harbor up` command. Harbor then fetches the exact skills defined in the manifest, cross-compiles them for the developer's specific agent (Claude, Cursor, Gemini), safely stows away any conflicting personal skills, and automatically generates a "Lighthouse" system prompt to teach the agent how to use its new capabilities.
 *   **Best for**: Team workspaces. If your goal is: *"I need all 50 engineers on my team to share the exact same custom AI coding standards, strictly locked down, and cross-compiled for 4 different IDEs without manual configuration,"* then you need Skill Harbor.
 
+Harbor is intentionally **skills-first**, not a general-purpose synchronizer for every AI config artifact. For that product boundary, see **[Architecture & Product Boundary](/docs/foundations/architecture)**.
+
 ---
 
 ## Why I didn't use Skills.sh inside of Skill Harbor
@@ -63,4 +65,5 @@ If `skills.sh` handles the fetching and installation independently, Skill Harbor
 
 ## Related FAQ
 
-If you're specifically evaluating Skill Harbor against the newer SkillsBench research, see **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**.
+- If you're specifically evaluating Skill Harbor against the newer SkillsBench research, see **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**.
+- If you're comparing catalog/governance platforms versus runtime delivery, see **[Why Not Agent Skill Harbor?](/docs/faq/agent-skill-harbor)**.

--- a/docs/faq/meta.json
+++ b/docs/faq/meta.json
@@ -2,6 +2,7 @@
   "title": "FAQ",
   "pages": [
     "comparison",
+    "agent-skill-harbor",
     "skillsbench"
   ]
 }

--- a/docs/foundations/architecture.mdx
+++ b/docs/foundations/architecture.mdx
@@ -1,0 +1,135 @@
+---
+title: Architecture & Product Boundary
+description: "What Skill Harbor is, what it is not, and how that shapes the system."
+icon: "waypoints"
+---
+
+# ⚓ Architecture & Product Boundary
+
+Skill Harbor works best when its scope stays sharp.
+
+This page defines what Skill Harbor **is**, what it **is not**, and how that boundary shapes the architecture of the system.
+
+---
+
+## What Skill Harbor is
+
+Skill Harbor is a **skills-first orchestration and governance system** for engineers and engineering teams.
+
+More specifically, it is:
+
+- a **trusted internal skill supply chain**
+- a **skills refinement and distribution engine**
+- a **team standardization layer** for `SKILL.md`-style artifacts
+- a place to **learn better skill technique** through curation, validation, profiling, and authoring guidance
+
+That means Harbor is not just a place to copy files. It is the layer that helps teams:
+
+- fetch the right skills
+- adapt them for different agent environments
+- berth them consistently
+- validate them
+- profile their quality and cost
+- keep strong skills in circulation
+
+---
+
+## What Skill Harbor is not
+
+Skill Harbor is **not**:
+
+- a general-purpose rules engine
+- a subagent-management framework
+- a broad workspace configuration synchronizer
+- a replacement for every downstream tool's full ecosystem model
+
+Harbor may integrate with tools that support those broader surfaces, but Harbor itself remains centered on **skills**.
+
+That distinction matters because product sprawl would weaken the thing Harbor is trying to be best at: helping individuals and teams use skills well.
+
+---
+
+## The architectural consequence
+
+Because Harbor is skills-first, the architecture should preserve a strict boundary:
+
+1. **Moor** — fetch raw skill cargo
+2. **Process** — refine/adapt skill cargo for a target environment
+3. **Berth** — place the adapted skill cargo into the right destination
+
+Harbor stays the system that owns that flow.
+
+External tools may help with part of the pipeline, but they should not erase Harbor's responsibility for:
+
+- skill orchestration
+- skill refinement
+- skill validation
+- skill governance
+- skill education and documentation
+
+If an integration makes Harbor less authoritative about skills, it is probably the wrong integration shape.
+
+---
+
+## Why this matters for RuleSync
+
+RuleSync is useful, but Harbor should only adopt it in ways that remain **skills-only**.
+
+That means the important question is not:
+
+> "Should Harbor become a full RuleSync-style context orchestrator?"
+
+It is:
+
+> "Should Harbor support a skills-only RuleSync integration path where that improves skill delivery without weakening Harbor's refinement and governance role?"
+
+Within that boundary, Harbor can support three increasingly strong shapes:
+
+### 1. Target-only support
+
+Harbor berths processed skills into RuleSync-managed skill locations such as `~/.rulesync/skills`.
+
+### 2. Skills-only RuleSync-backed processing
+
+Harbor may optionally support a more explicit RuleSync-backed skills path, but only if the implementation still preserves Harbor's ownership of skill refinement and verification.
+
+### 3. Optional bridge behavior
+
+Harbor may optionally trigger a post-`up` RuleSync command, but only as an opt-in workflow enhancement and not as a default behavior for all users.
+
+---
+
+## What Harbor should explicitly reject
+
+Even if a downstream tool supports them, Harbor should reject scope creep into:
+
+- general rules distribution
+- subagent synchronization
+- non-skill workspace config management
+- broad "one tool for every AI config artifact" positioning
+
+Those capabilities may be useful elsewhere, but they are not Harbor's center of gravity.
+
+---
+
+## Harbor's long-term differentiation
+
+The strongest version of Skill Harbor is not "the tool that touches the most artifact types."
+
+It is:
+
+- the tool that understands **skills** best
+- the tool that helps teams **govern** skills
+- the tool that helps engineers **learn better skill technique**
+- the tool that turns a pile of prompt files into a **portable, auditable, high-signal skill fleet**
+
+That is the product boundary this architecture should protect.
+
+---
+
+## Related reading
+
+- [Manifest & `.harbor` Folder](/docs/foundations/manifest)
+- [Governance](/docs/foundations/governance)
+- [The Toolkit (Meta-Skills)](/docs/foundations/toolkit)
+- [Why Not Skills.sh?](/docs/faq/comparison)

--- a/docs/foundations/meta.json
+++ b/docs/foundations/meta.json
@@ -5,6 +5,7 @@
     "fathom",
     "voyager",
     "manifest",
+    "architecture",
     "toolkit",
     "governance"
   ]

--- a/docs/foundations/toolkit.mdx
+++ b/docs/foundations/toolkit.mdx
@@ -8,6 +8,8 @@ icon: "toolbox"
 
 Skill Harbor is not just a sync engine—it is an **Agent Authoring Partner**. Instead of manual scaffolding, we provide a set of **AI-Native Meta-Skills** (Tools) that can be docked directly into your harbor to help you build, evaluate, and standardize your fleet.
 
+These tools reinforce Harbor's role as a **skills-first** system. They are meant to improve how teams author, audit, and operate skills—not to broaden Harbor into a general rules or workspace-config platform. See [Architecture & Product Boundary](/docs/foundations/architecture).
+
 ## ⚓ The Toolkit Collection
 
 These meta-skills aren't part of the CLI itself—they are **Doctor-Sourced Skills** that you run with your favorite agent (Claude, Cursor, Codex, Antigravity) to help manage your other skills.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -22,6 +22,9 @@ Instead of manual skill installation or fragile global configurations, Skill Har
   <Card title="🛳️ Multi-Target Berthing" icon="ship">
     During `skill-harbor up`, one manifest can deploy consistent skill context to Claude, Cursor, Codex, Gemini, Windsurf, Copilot, and other supported targets.
   </Card>
+  <Card title="🧱 Skills-First Architecture" icon="waypoints" href="/docs/foundations/architecture">
+    Skill Harbor stays focused on skills: fetch, refine, govern, and berth them well without expanding into every other config surface.
+  </Card>
   <Card title="🛡️ Governance Controls" icon="shield" href="/docs/reference/commands">
     Use `up --lockdown`, `stow`, `unstow`, `undock`, and `migrate` to control what agents can see and to safely manage state over time.
   </Card>
@@ -59,6 +62,8 @@ At the heart of the harbor is the **[Skill Standard](/docs/skill-standards)**. W
 - **Strategic Headers**: `Purpose`, `Trigger`, and `Guidelines` for deterministic routing.
 - **Semantic Contracts**: Optional `Requires` and `Produces` keys to allow for safe skill chaining.
 - **Displacement Math**: Automated token counting to keep your "context wake" small.
+
+Harbor is intentionally **skills-first**. For the architectural boundary behind that decision, see **[Architecture & Product Boundary](/docs/foundations/architecture)**.
 
 
 ## 🧠 The Necessity of Curated Registries
@@ -128,6 +133,7 @@ Skill Harbor is built for the **Solo Captain** and the **Full Fleet Command**.
 
 - **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**
 - **[Why Not Skills.sh?](/docs/faq/comparison)**
+- **[Why Not Agent Skill Harbor?](/docs/faq/agent-skill-harbor)**
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "test": "turbo run test",
-    "lint": "turbo run lint"
+    "lint": "turbo run lint",
+    "quartermaster": "bun ./scripts/quartermaster.ts"
   },
   "workspaces": [
     "apps/*"

--- a/scripts/quartermaster.ts
+++ b/scripts/quartermaster.ts
@@ -2,14 +2,18 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import readline from 'node:readline/promises';
+import { fileURLToPath } from 'node:url';
 import kleur from 'kleur';
 import ora from 'ora';
 import dotenv from 'dotenv';
 import boxen from 'boxen';
 
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+
 // Load .env and .env.local
 dotenv.config();
-dotenv.config({ path: path.join(process.cwd(), '.env.local'), override: true });
+dotenv.config({ path: path.join(repoRoot, '.env.local'), override: true });
 
 const GROQ_API_KEY = process.env.GROQ_API_KEY;
 const MODEL = "llama-3.3-70b-versatile";
@@ -19,7 +23,7 @@ async function getDiff() {
         // Find the base branch (defaulting to main)
         const baseBranch = 'main';
         // Use 'git diff baseBranch' to include committed + staged + unstaged changes
-        return execSync(`git diff ${baseBranch}`, { encoding: 'utf-8' });
+        return execSync(`git diff ${baseBranch}`, { encoding: 'utf-8', cwd: repoRoot });
     } catch (error) {
         console.error(kleur.red('The Quartermaster is lost! Failed to get git diff.'));
         process.exit(1);
@@ -138,7 +142,7 @@ async function run() {
 
     // Create the changeset file
     const changesetName = `quartermaster-${Date.now().toString(36)}`;
-    const changesetPath = path.join(process.cwd(), '.changeset', `${changesetName}.md`);
+    const changesetPath = path.join(repoRoot, '.changeset', `${changesetName}.md`);
     
     const content = `---
 "skill-harbor": ${suggestion.bump}
@@ -161,5 +165,4 @@ run().catch(err => {
     console.error(kleur.red(`\nIncident at sea: ${err.message}`));
     process.exit(1);
 });
-
 


### PR DESCRIPTION
## Summary
Fix the modernized version of #4 by making concurrent `skill-harbor up` output deterministic instead of animated.

## Why
Issue #4 was originally filed around `ora`, but the audit showed the underlying problem was broader terminal UX during parallel sync work. The current code already uses `spinnies`, but concurrent skill sync still runs via `Promise.all`, and mixed parallel spinner output is still noisy/fragile.

## What changed
- updated `apps/cli/src/commands/up.ts` to instantiate `Spinnies` with `disableSpins: true` for the concurrent sync path
- added regression coverage in `apps/cli/src/commands/up.test.ts` to ensure sync animation stays disabled
- added a patch changeset

## Why this fix
This keeps sync semantics unchanged while preferring stable, readable progress lines over animated multi-spinner rendering.

## Verification
- `./node_modules/.bin/vitest run src/commands/up.test.ts src/orchestrator.test.ts`
- `./node_modules/.bin/vitest run`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `bun run build`

## Related issue
- Closes #4
