### PR TITLE
Restore npm publishing after merged changeset release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ on:
   push:
     branches:
       - main
+  # Changesets includes [skip ci] in the version-PR commit body, so the merge
+  # commit on main can skip push-triggered workflows unless we also listen for
+  # the PR closing event.
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -15,11 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
+          # pull_request:closed runs on the PR head by default; publish must run
+          # against the merged main branch state.
+          ref: ${{ github.event_name == 'pull_request' && 'main' || '' }}
           fetch-depth: 0
 
       - name: Setup Bun
@@ -49,7 +63,7 @@ jobs:
 
       # --- Mode 1: Pending changesets exist → create/update the Version PR ---
       - name: Create Release Pull Request
-        if: steps.check.outputs.has_changesets == 'true'
+        if: steps.check.outputs.has_changesets == 'true' && github.event_name != 'pull_request'
         uses: changesets/action@v1
         with:
           createGithubReleases: false


### PR DESCRIPTION
## Summary
- restore the `pull_request.closed` path for merged `changeset-release/*` PRs
- publish from the merged `main` state instead of the PR head
- keep the version-PR creation step out of the PR-close publish path

## Why
Merged release PR commits still contain `[skip ci]`, so the push-triggered release workflow does not run after those merges. That left npm stuck at `0.12.0` even though GitHub releases and tags continued through `v0.19.0`.

## Evidence
- PR #73 merged from `changeset-release/main` into `main` on 2026-04-19, but no Release workflow ran for merge SHA `3e81ee1e88d25802aeb11797b18539ac0450a8f3`
- `release.yml` at that merge commit listened only to `push` and `workflow_dispatch`
- npm registry backfill is now complete through `0.19.0`

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`
- `bun run lint`
- `bun run test`
- `bun run build`
- `npm view skill-harbor version versions time --json`
