### PR TITLE
Fix cached-cargo sync regressions after the release workflow recovery

### DIFF
--- a/.changeset/quartermaster-mo6q61a0.md
+++ b/.changeset/quartermaster-mo6q61a0.md
@@ -1,0 +1,12 @@
+"skill-harbor": patch
+---
+
+<!-- hero: Calmer Waters for Cached Cargo -->
+
+## Captain's Briefing
+Skill Harbor now recovers more cleanly when a berth goes missing but the cargo is still cached in Harbor. The orchestrator keeps its status line alive across cached-cargo sync paths, so a follow-up `up` can actually re-berth the skill instead of failing mid-voyage.
+
+## 🛠️ Barnacle Scraping (Technical Fixes)
+* Added `ensureSpinnerActive` in `apps/cli/src/orchestrator.ts` and routed `moor`, `processCargo`, `berth`, and `finalize` through it so cached-cargo sync paths no longer throw `No spinner initialized with name sync-<skill>`.
+* Switched the explicit helper-binary spawns in `apps/cli/src/orchestrator.ts` to `shell: false`, removing the noisy `DEP0190` child-process warning during `skill-harbor up`.
+* Added regression coverage in `apps/cli/src/orchestrator.test.ts` for re-berthing cached cargo and processing cached cargo without a prior moor spinner.

--- a/apps/cli/src/orchestrator.test.ts
+++ b/apps/cli/src/orchestrator.test.ts
@@ -3,6 +3,7 @@ import { Orchestrator } from './orchestrator';
 import Spinnies from 'spinnies';
 import path from 'path';
 import fs from 'node:fs/promises';
+import { chmodSync } from 'node:fs';
 import os from 'node:os';
 
 describe('Orchestrator Unit Tests', () => {
@@ -78,6 +79,68 @@ describe('Orchestrator Unit Tests', () => {
         });
 
         await expect((nestedOrchestrator as any).resolveLocalBin('skillfish')).resolves.toBe(expectedPath);
+
+        await nestedOrchestrator.cleanup();
+        await fs.rm(workspaceRoot, { recursive: true, force: true });
+    });
+
+    it('should berth cached cargo even when no spinner has been initialized yet', async () => {
+        const cargoPath = path.join(tempDir, 'cached-cargo');
+        const targetPath = path.join(tempDir, 'target-skill');
+
+        await fs.mkdir(cargoPath, { recursive: true });
+        await fs.writeFile(path.join(cargoPath, 'SKILL.md'), '---\nname: cached-skill\ndescription: cached skill\n---\n');
+
+        await expect(orchestrator.berth(cargoPath, targetPath, 'Codex')).resolves.toBe(true);
+        await expect(fs.readFile(path.join(targetPath, 'SKILL.md'), 'utf-8')).resolves.toContain('cached-skill');
+
+        expect(() => orchestrator.finalize('Successfully berthed to: Codex')).not.toThrow();
+    });
+
+    it('should process cached cargo without requiring a prior moor spinner', async () => {
+        const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-harbor-workspace-'));
+        const nestedPackageRoot = path.join(workspaceRoot, 'apps', 'cli');
+        const binDir = path.join(workspaceRoot, 'node_modules', '.bin');
+        const binaryName = process.platform === 'win32' ? 'skill-porter.cmd' : 'skill-porter';
+        const scriptPath = path.join(binDir, binaryName);
+        const cargoPath = path.join(tempDir, 'cargo-to-process');
+
+        await fs.mkdir(binDir, { recursive: true });
+        await fs.mkdir(nestedPackageRoot, { recursive: true });
+        await fs.mkdir(cargoPath, { recursive: true });
+        await fs.writeFile(path.join(cargoPath, 'SKILL.md'), '---\nname: cached-skill\ndescription: cached skill\n---\n');
+
+        if (process.platform === 'win32') {
+            await fs.writeFile(
+                scriptPath,
+                '@echo off\r\n' +
+                'setlocal\r\n' +
+                'set "input=%2"\r\n' +
+                'set "output=%6"\r\n' +
+                'mkdir "%output%" >nul 2>&1\r\n' +
+                'xcopy "%input%\\*" "%output%\\" /E /I /Y >nul\r\n'
+            );
+        } else {
+            await fs.writeFile(
+                scriptPath,
+                '#!/usr/bin/env sh\n' +
+                'input="$2"\n' +
+                'output="$6"\n' +
+                'mkdir -p "$output"\n' +
+                'cp -R "$input"/. "$output"/\n'
+            );
+            chmodSync(scriptPath, 0o755);
+        }
+
+        const nestedOrchestrator = new Orchestrator({
+            skillName: 'cached-skill',
+            spinnies,
+            packageRoot: nestedPackageRoot
+        });
+
+        const processedPath = await nestedOrchestrator.processCargo(cargoPath, 'claude');
+
+        await expect(fs.readFile(path.join(processedPath, 'SKILL.md'), 'utf-8')).resolves.toContain('cached-skill');
 
         await nestedOrchestrator.cleanup();
         await fs.rm(workspaceRoot, { recursive: true, force: true });

--- a/apps/cli/src/orchestrator.ts
+++ b/apps/cli/src/orchestrator.ts
@@ -36,6 +36,15 @@ export class Orchestrator {
         return `sync-${this.skillName}`;
     }
 
+    private ensureSpinnerActive(text: string): void {
+        if (!this.spinnies.pick(this.spinnerId)) {
+            this.spinnies.add(this.spinnerId, { text });
+            return;
+        }
+
+        this.spinnies.update(this.spinnerId, { text });
+    }
+
     private async resolveLocalBin(binaryName: string): Promise<string> {
         const executableName = process.platform === "win32" ? `${binaryName}.cmd` : binaryName;
         let currentDir = path.resolve(this.packageRoot);
@@ -56,7 +65,7 @@ export class Orchestrator {
     }
 
     async moor(url: string): Promise<string> {
-        this.spinnies.add(this.spinnerId, { text: kleur.cyan(`[${this.skillName}] Mooring skill from ${url}...`) });
+        this.ensureSpinnerActive(kleur.cyan(`[${this.skillName}] Mooring skill from ${url}...`));
         try {
             await fs.mkdir(this.tempDir, { recursive: true });
 
@@ -105,7 +114,7 @@ export class Orchestrator {
 
             const child = spawn(binPath, args, {
                 cwd: this.tempDir,
-                shell: true,
+                shell: false,
                 stdio: ["pipe", "pipe", "pipe"]
             });
 
@@ -153,7 +162,7 @@ export class Orchestrator {
     }
 
     async processCargo(cargoPath: string, targetAgent: string): Promise<string> {
-        this.spinnies.update(this.spinnerId, { text: kleur.cyan(`[${this.skillName}] Processing cargo for ${targetAgent}...`) });
+        this.ensureSpinnerActive(kleur.cyan(`[${this.skillName}] Processing cargo for ${targetAgent}...`));
         try {
             const outputPath = path.join(this.tempDir, "processed", targetAgent);
             await fs.mkdir(outputPath, { recursive: true });
@@ -162,7 +171,7 @@ export class Orchestrator {
             const args = ["convert", cargoPath, "-t", targetAgent, "-o", outputPath];
 
             const child = spawn(binPath, args, {
-                shell: true,
+                shell: false,
                 stdio: ["ignore", "pipe", "pipe"]
             });
 
@@ -194,7 +203,7 @@ export class Orchestrator {
             return false;
         }
 
-        this.spinnies.update(this.spinnerId, { text: kleur.cyan(`[${this.skillName}] Transporting to ${label} berth...`) });
+        this.ensureSpinnerActive(kleur.cyan(`[${this.skillName}] Transporting to ${label} berth...`));
         try {
             // Fix: Proactively handle existing files or broken symlinks at targetPath
             const stats = await fs.lstat(targetPath).catch(() => null);
@@ -387,6 +396,7 @@ export class Orchestrator {
     }
 
     public finalize(message: string): void {
+        this.ensureSpinnerActive(kleur.green(`[${this.skillName}] ${message}`));
         this.spinnies.succeed(this.spinnerId, { text: kleur.bold().green(`[${this.skillName}] ${message}`) });
     }
 }


### PR DESCRIPTION
## Summary
- fix cached-cargo sync paths so `skill-harbor up` can re-berth missing skills without throwing spinner errors
- switch helper binary spawns to `shell: false` to avoid the `DEP0190` warning during sync
- add a Quartermaster-generated changeset for the patch release

## Why
After the release-pipeline fix from #74, a follow-up bug report showed that deleting a berthed skill and rerunning `skill-harbor up --global --target codex` could leave the skill stranded in Dry Dock. The cached-cargo sync path reused Harbor cache instead of re-mooring the source, but the orchestrator only initialized its spinner inside `moor()`. That made later `processCargo`, `berth`, and `finalize` calls fail with `No spinner initialized with name sync-<skill>`, and `fathom --details` kept reporting the skill as missing.

## What changed
- added `ensureSpinnerActive` in `apps/cli/src/orchestrator.ts`
- routed `moor`, `processCargo`, `berth`, and `finalize` through the resilient spinner path
- changed explicit helper-binary `spawn` calls to `shell: false`
- added orchestrator regression tests for cached-cargo berthing and processing
- ran Quartermaster and kept the resulting changeset as `.changeset/quartermaster-mo6q61a0.md`

## Verification
- `cd apps/cli && bun run vitest run src/orchestrator.test.ts src/commands/up.test.ts src/commands/fathom.test.ts`
- `bun run lint`
- `bun run test`
- `bun run build`

## Related
- follow-up to #74, which was already merged before this additional fix was requested
