### PR TITLE
Fix the malformed changeset frontmatter on main

### DIFF
--- a/.changeset/quartermaster-mo6q61a0.md
+++ b/.changeset/quartermaster-mo6q61a0.md
@@ -1,3 +1,4 @@
+---
 "skill-harbor": patch
 ---
 


### PR DESCRIPTION
## Summary
- restore the missing opening frontmatter delimiter in `.changeset/quartermaster-mo6q61a0.md`

## Why
The merged changeset file on `main` was missing its first `---`, so `changesets/action` could not parse the frontmatter and the release workflow failed before it could create or update the version PR.

## Verification
- `npx changeset status`
