### PR TITLE
Separate post-merge publishing and show full Fathom berth scope

### DIFF
--- a/.changeset/steady-release-tides.md
+++ b/.changeset/steady-release-tides.md
@@ -1,0 +1,16 @@
+---
+"skill-harbor": patch
+---
+
+<!-- hero: Steadier Releases and Clearer Berths -->
+
+## Captain's Briefing
+
+The harbor now has a sturdier post-merge release route, and Fathom reports berth placement with a fuller view of the active fleet. This patch focuses on reliability: releases should publish after a merged Changesets PR, and berth reporting should reflect every active agent match in the chosen scope.
+
+## 🛠️ Barnacle Scraping (Technical Fixes)
+
+- Split release automation into a dedicated publish workflow so merged `changeset-release/*` PRs can publish from a `pull_request_target` close event instead of relying on merge-commit push behavior.
+- Added a guard that refuses to publish when pending `.changeset/*.md` files are still present, so the publish workflow only runs on versioned release states.
+- Updated `fathom` berth-status discovery to scan all active berths in the selected local/global scope, so skills can show multiple matches such as Codex plus Rulesync instead of only the manifest-target subset.
+- Added regression coverage for the expanded multi-berth Fathom status output.

--- a/.changeset/steady-release-tides.md
+++ b/.changeset/steady-release-tides.md
@@ -6,11 +6,12 @@
 
 ## Captain's Briefing
 
-The harbor now has a sturdier post-merge release route, and Fathom reports berth placement with a fuller view of the active fleet. This patch focuses on reliability: releases should publish after a merged Changesets PR, and berth reporting should reflect every active agent match in the chosen scope.
+The harbor now has a sturdier post-merge release route, and Fathom reports berth placement with a fuller, quieter view of the active fleet. This patch focuses on reliability and operator clarity: releases should publish after a merged Changesets PR, berth reporting should reflect every active agent match in the chosen scope, and default Fathom rows should keep the common Agent Skill case out of the way unless details are requested.
 
 ## 🛠️ Barnacle Scraping (Technical Fixes)
 
 - Split release automation into a dedicated publish workflow so merged `changeset-release/*` PRs can publish from a `pull_request_target` close event instead of relying on merge-commit push behavior.
 - Added a guard that refuses to publish when pending `.changeset/*.md` files are still present, so the publish workflow only runs on versioned release states.
 - Updated `fathom` berth-status discovery to scan all active berths in the selected local/global scope, so skills can show multiple matches such as Codex plus Rulesync instead of only the manifest-target subset.
-- Added regression coverage for the expanded multi-berth Fathom status output.
+- Quieted Fathom's default type display by hiding the routine `Agent Skill` badge while still surfacing `API Tool` when it matters, and added an explicit `Type` explanation row in `--details` output.
+- Added regression coverage for both the expanded multi-berth Fathom status output and the new default/details type-display behavior.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,89 @@
+name: Publish Release
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # For merged changeset PRs we want the merged main branch state.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Ensure versioned release state
+        run: |
+          CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" | head -1 || true)
+          if [ -n "$CHANGESETS" ]; then
+            echo "Refusing to publish with pending changesets still present: $CHANGESETS"
+            exit 1
+          fi
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to NPM
+        run: npx changeset publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        run: |
+          VERSION=$(node -p "require('./apps/cli/package.json').version")
+          TAG="v$VERSION"
+
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+          HERO_TITLE=$(grep -A 10 "## $VERSION" apps/cli/CHANGELOG.md | grep "## ⚓" | head -n 1 | sed 's/## ⚓ //')
+          sed -n "/## $VERSION/,/## [0-9]/p" apps/cli/CHANGELOG.md | sed '1d;$d' > release_notes.md
+
+          if [ -z "$HERO_TITLE" ]; then
+            FINAL_TITLE="⚓ Skill Harbor v$VERSION"
+          else
+            FINAL_TITLE="⚓ Skill Harbor v$VERSION: $HERO_TITLE"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating existing release $TAG"
+            gh release edit "$TAG" --title "$FINAL_TITLE" --notes-file release_notes.md
+          else
+            echo "Creating new release $TAG"
+            gh release create "$TAG" --title "$FINAL_TITLE" --notes-file release_notes.md
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,6 @@
-name: Release
+name: Release PR
 on:
   push:
-    branches:
-      - main
-  # Changesets includes [skip ci] in the version-PR commit body, so the merge
-  # commit on main can skip push-triggered workflows unless we also listen for
-  # the PR closing event.
-  pull_request:
-    types:
-      - closed
     branches:
       - main
   workflow_dispatch:
@@ -18,22 +10,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  release:
-    name: Release
+  release-pr:
+    name: Create Release PR
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          # pull_request:closed runs on the PR head by default; publish must run
-          # against the merged main branch state.
-          ref: ${{ github.event_name == 'pull_request' && 'main' || '' }}
           fetch-depth: 0
 
       - name: Setup Bun
@@ -61,60 +44,12 @@ jobs:
             echo "has_changesets=false" >> $GITHUB_OUTPUT
           fi
 
-      # --- Mode 1: Pending changesets exist → create/update the Version PR ---
       - name: Create Release Pull Request
-        if: steps.check.outputs.has_changesets == 'true' && github.event_name != 'pull_request'
+        if: steps.check.outputs.has_changesets == 'true'
         uses: changesets/action@v1
         with:
           createGithubReleases: false
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # --- Mode 2: No changesets → Version PR was merged, publish! ---
-      - name: Build
-        if: steps.check.outputs.has_changesets == 'false'
-        run: npm run build
-
-      - name: Publish to NPM
-        if: steps.check.outputs.has_changesets == 'false'
-        run: npx changeset publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
-        if: steps.check.outputs.has_changesets == 'false'
-        run: |
-          VERSION=$(node -p "require('./apps/cli/package.json').version")
-          TAG="v$VERSION"
-
-          # Check if the tag already exists (changeset publish may have created it)
-          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-            git tag "$TAG"
-            git push origin "$TAG"
-          fi
-
-          # Extract Hero Title from CHANGELOG.md
-          HERO_TITLE=$(grep -A 10 "## $VERSION" apps/cli/CHANGELOG.md | grep "## ⚓" | head -n 1 | sed 's/## ⚓ //')
-
-          # Extract release notes for this version from CHANGELOG.md
-          sed -n "/## $VERSION/,/## [0-9]/p" apps/cli/CHANGELOG.md | sed '1d;$d' > release_notes.md
-
-          if [ -z "$HERO_TITLE" ]; then
-            FINAL_TITLE="⚓ Skill Harbor v$VERSION"
-          else
-            FINAL_TITLE="⚓ Skill Harbor v$VERSION: $HERO_TITLE"
-          fi
-
-          # Create or update the GitHub release
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Updating existing release $TAG"
-            gh release edit "$TAG" --title "$FINAL_TITLE" --notes-file release_notes.md
-          else
-            echo "Creating new release $TAG"
-            gh release create "$TAG" --title "$FINAL_TITLE" --notes-file release_notes.md
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/cli/src/commands/fathom.test.ts
+++ b/apps/cli/src/commands/fathom.test.ts
@@ -250,6 +250,88 @@ describe("fathomAction", () => {
         logSpy.mockRestore();
     });
 
+    it("hides the Agent Skill type badge in default output", async () => {
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        const options = {};
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                skill1: { name: "skill1", source: "source1", layer: "shared" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "skill1", layer: "shared" }]);
+        (exists as any).mockImplementation(async (candidatePath: string) => (
+            candidatePath === "/harbor/skill1"
+        ));
+        mockProfiler.calculateDisplacement.mockResolvedValue({
+            icon: "🛳️",
+            shipClass: "Frigate",
+            tokens: 5001,
+            cost: { gpt4o: 0.025, gpt4oMini: 0.00075 }
+        });
+        mockProfiler.calculateHeuristicConfidence.mockResolvedValue({
+            score: 10,
+            condition: "Glassy Water",
+            skillType: "Agent Skill",
+            validation: { isProperlyFormatted: true, errors: [] },
+            heuristics: {
+                semanticVagueness: -1,
+                negativeConstraints: 0,
+                tagDensity: -2,
+                triggerClarity: -1
+            },
+            contracts: null
+        });
+
+        await fathomAction(options, mockCommand);
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("✓ [skill1]"));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("<Agent Skill>"));
+        logSpy.mockRestore();
+    });
+
+    it("shows API Tool in the default line and explains the type in details mode", async () => {
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        const options = { details: true };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                tool1: { name: "tool1", source: "source1", layer: "shared" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "tool1", layer: "shared" }]);
+        (exists as any).mockImplementation(async (candidatePath: string) => (
+            candidatePath === "/harbor/tool1"
+        ));
+        mockProfiler.calculateDisplacement.mockResolvedValue({
+            icon: "🚤",
+            shipClass: "Brigantine",
+            tokens: 1646,
+            cost: { gpt4o: 0.0082, gpt4oMini: 0.000247 }
+        });
+        mockProfiler.calculateHeuristicConfidence.mockResolvedValue({
+            score: 9,
+            condition: "Glassy Water",
+            skillType: "API Tool",
+            validation: { isProperlyFormatted: true, errors: [] },
+            heuristics: {
+                semanticVagueness: 0,
+                negativeConstraints: -1,
+                schemaStrictness: -2
+            },
+            contracts: null
+        });
+
+        await fathomAction(options, mockCommand);
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("<API Tool>"));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Type"));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("tool/schema-style asset"));
+        logSpy.mockRestore();
+    });
+
     it("adds structured vessel placement detail to report output", async () => {
         const options = { report: true, format: "json" };
         const mockCommand = { opts: vi.fn().mockReturnValue(options) };

--- a/apps/cli/src/commands/fathom.test.ts
+++ b/apps/cli/src/commands/fathom.test.ts
@@ -165,6 +165,7 @@ describe("fathomAction", () => {
         (discoverGhosts as any).mockResolvedValue([
             { name: "ghost-skill", path: "/ghosts/ghost-skill", location: "berth", berthLabel: "Codex", friendly: false }
         ]);
+        (getAgentBerths as any).mockResolvedValue([{ path: "/codex", label: "Codex", key: "codex" }]);
         (exists as any).mockImplementation(async (candidatePath: string) => (
             candidatePath === "/ghosts/ghost-skill" || candidatePath === "/codex/ghost-skill"
         ));
@@ -192,6 +193,60 @@ describe("fathomAction", () => {
 
         expect(resolveGhostScanContext).toHaveBeenCalledTimes(1);
         expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[Berthed: Codex | .codex]"));
+        logSpy.mockRestore();
+    });
+
+    it("shows every berthed agent match available in the selected scope", async () => {
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        const options = { global: true };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.read.mockResolvedValue({
+            skills: {
+                catch22: { name: "catch-22", source: "source1", layer: "global" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "catch-22", layer: "global" }]);
+        (resolveCommandScope as any).mockResolvedValue({ useGlobalScope: true, shouldStop: false });
+        (getAgentBerths as any).mockResolvedValue([
+            { path: "/rulesync", label: "Rulesync", key: "rulesync" },
+            { path: "/codex", label: "Codex", key: "codex" }
+        ]);
+        (exists as any).mockImplementation(async (candidatePath: string) => (
+            candidatePath === "/harbor/catch-22" ||
+            candidatePath === "/rulesync/catch-22" ||
+            candidatePath === "/codex/catch-22"
+        ));
+        (getAgentBerthLocation as any).mockImplementation((berth: any) => {
+            if (berth.path === "/rulesync") return ".rulesync";
+            if (berth.path === "/codex") return ".codex";
+            return undefined;
+        });
+        mockProfiler.calculateDisplacement.mockResolvedValue({
+            icon: "🛳️",
+            shipClass: "Frigate",
+            tokens: 5001,
+            cost: { gpt4o: 0.025, gpt4oMini: 0.00075 }
+        });
+        mockProfiler.calculateHeuristicConfidence.mockResolvedValue({
+            score: 10,
+            condition: "Glassy Water",
+            skillType: "Agent Skill",
+            validation: { isProperlyFormatted: true, errors: [] },
+            heuristics: {
+                semanticVagueness: -1,
+                negativeConstraints: 0,
+                tagDensity: -2,
+                triggerClarity: -1
+            },
+            contracts: null
+        });
+
+        await fathomAction(options, mockCommand);
+
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining("[Berthed: Rulesync | .rulesync, Codex | .codex]")
+        );
         logSpy.mockRestore();
     });
 

--- a/apps/cli/src/commands/fathom.ts
+++ b/apps/cli/src/commands/fathom.ts
@@ -69,13 +69,12 @@ export async function fathomAction(options: any, command: any) {
         let skills: any[] = manifestManager.materializeSkills(manifest);
         const ghostSkillPaths: string[] = [];
         let friendlyGhostCount = 0;
-        let ghostSkillNames = new Set<string>();
         let ghostScanContext: GhostScanContext | null = null;
 
         // 2.5 Active Berths Discovery
         const baseDir = useGlobalScope ? os.homedir() : process.cwd();
-        const activeBerths = await getAgentBerths(baseDir, manifest.targets);
-        const stowageBerths = await getStowageBerths(baseDir, manifest.targets);
+        const activeBerths = await getAgentBerths(baseDir);
+        const stowageBerths = await getStowageBerths(baseDir);
 
         // 2.6 Ghost Skill Discovery (Active Berths)
         if (opts.ghosts) {
@@ -94,7 +93,6 @@ export async function fathomAction(options: any, command: any) {
             });
             const { active, friendly } = summarizeGhosts(ghosts);
             friendlyGhostCount = friendly.length;
-            ghostSkillNames = new Set(active.map(ghost => ghost.name));
             for (const ghost of active) {
                 ghostSkillPaths.push(ghost.path);
                 if (!showReport) {
@@ -170,10 +168,7 @@ export async function fathomAction(options: any, command: any) {
             const allPossibleVessels = [...new Set([...skills.map(s => s.name), ...skillPaths.map(p => path.basename(p))])];
             
             for (const name of allPossibleVessels) {
-                const berthContext = ghostSkillNames.has(name) && ghostScanContext
-                    ? ghostScanContext
-                    : { activeBerths, stowageBerths };
-                const status = await getVesselStatus(name, berthContext.activeBerths, berthContext.stowageBerths);
+                const status = await getVesselStatus(name, activeBerths, stowageBerths);
                 if (status.berthed.length > 0 || status.stowed.length > 0) {
                     vesselPlacements.push({
                         name,
@@ -213,10 +208,7 @@ export async function fathomAction(options: any, command: any) {
                     skill.name
                 );
             
-            const berthContext = skill.isGhost && ghostScanContext
-                ? ghostScanContext
-                : { activeBerths, stowageBerths };
-            const vStatus = await getVesselStatus(skill.name, berthContext.activeBerths, berthContext.stowageBerths);
+            const vStatus = await getVesselStatus(skill.name, activeBerths, stowageBerths);
             let statusLabel = "";
             let statusColor = kleur.gray;
 

--- a/apps/cli/src/commands/fathom.ts
+++ b/apps/cli/src/commands/fathom.ts
@@ -274,7 +274,9 @@ export async function fathomAction(options: any, command: any) {
                     sonarText = `[${bar}] ${sonarColor(sonarResult.score + "%")} (via ${sonarResult.model})`;
                 }
 
-                const typeEmoji = heuristic.skillType === "API Tool" ? "🔧" : "🧠";
+                const typeBadge = heuristic.skillType === "API Tool"
+                    ? ` 🔧 ${kleur.blue("<API Tool>")}`
+                    : "";
                 const validationEmoji = heuristic.validation.isProperlyFormatted ? "✅" : "⚠️";
 
                 const fmt = (v: number) => { const inv = -v; return inv > 0 ? `+${inv}` : `${inv}`; };
@@ -286,7 +288,7 @@ export async function fathomAction(options: any, command: any) {
                     heuristicSubtext = `${kleur.gray(`(Vagueness: ${fmt(heuristic.heuristics.semanticVagueness)}, Constraints: ${fmt(heuristic.heuristics.negativeConstraints)}, Tags: ${fmt(heuristic.heuristics.tagDensity ?? 0)}, Triggers: ${fmt(heuristic.heuristics.triggerClarity ?? 0)})`)}`;
                 }
 
-                console.log(`${kleur.green("✓")} [${kleur.bold(skill.name)}]${layerLabel}${statusColor(statusLabel)} ${typeEmoji} ${kleur.blue(`<${heuristic.skillType}>`)} ${validationEmoji}`);
+                console.log(`${kleur.green("✓")} [${kleur.bold(skill.name)}]${layerLabel}${statusColor(statusLabel)}${typeBadge} ${validationEmoji}`);
                 console.log(`    ${kleur.cyan("Displacement:")} ${displacementText}`);
                 console.log(`    ${kleur.cyan("Confidence (Heuristic):")} ${heuristicText} ${heuristicSubtext}`);
                 console.log(`    ${kleur.cyan("Confidence (Sonar):")}     ${sonarText}`);
@@ -317,6 +319,13 @@ export async function fathomAction(options: any, command: any) {
                     console.log("");
                     console.log(kleur.bold().cyan(`    📋 Heuristic Breakdown for ${skill.name}`));
                     console.log(kleur.gray("    ─────────────────────────────────────"));
+                    if (heuristic.skillType === "API Tool") {
+                        printDetailRow("Type", "API Tool",
+                            "Detected as a tool/schema-style asset, so Fathom evaluates it with API-tool heuristics such as schema strictness.");
+                    } else {
+                        printDetailRow("Type", "Agent Skill",
+                            "Detected as an instruction/prompt-style skill, so Fathom evaluates it with agent-skill heuristics such as tags and trigger clarity.");
+                    }
 
                     if (heuristic.skillType === "API Tool") {
                         printDetailRow("Vagueness", fmt(h.semanticVagueness),


### PR DESCRIPTION
## Summary
- split release automation into separate workflows for version-PR creation and post-merge publish
- publish merged Changesets PRs from a dedicated `pull_request_target` workflow instead of relying on merge-commit push behavior
- make `fathom` show every active berth match in the selected local/global scope, not just the manifest-target subset
- add regression coverage and a patch changeset for the new behavior

## Why
Two reliability gaps showed up in production use:

1. The release pipeline could still miss publishes after merging a `changeset-release/*` PR because no automatic publish run was created for the merge commit.
2. `fathom` berth labels could hide real live placements in the chosen scope. For example, a skill berthed in both Rulesync and Codex could be shown with only one berth match.

## What changed
### Release automation
- `release.yml` now handles only Changesets version-PR creation
- new `publish-release.yml` handles publishing/release creation after a merged `changeset-release/*` PR
- added a guard to refuse publishing when pending `.changeset/*.md` files still exist
- manual `workflow_dispatch` remains available as a fallback on the publish workflow

### Fathom
- berth-status discovery now scans all active berths in the selected scope (`--global` vs local)
- berth output can now show multiple matches such as `Rulesync | .rulesync, Codex | .codex`
- added regression coverage for the multi-berth output path

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/publish-release.yml')"`
- `npx changeset status`
- `bun run lint`
- `bun run test`
- `bun run build`

## Release note
- `.changeset/steady-release-tides.md`
