### PR TITLE
Add Voyager benchmark packs and document Benchmarking

### DIFF
--- a/.changeset/bright-mice-judge.md
+++ b/.changeset/bright-mice-judge.md
@@ -1,0 +1,5 @@
+---
+"skill-harbor": minor
+---
+
+Add Harbor-native Voyager benchmark packs for deterministic local and CI evaluation.

--- a/apps/cli/src/commands/voyager.test.ts
+++ b/apps/cli/src/commands/voyager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import matter from "gray-matter";
+import yaml from "js-yaml";
 import { voyagerAction } from "./voyager";
 import { resolveCommandScope } from "../command-scope";
 import { ask, getAgentBerths, getManifestManager } from "../utils";
@@ -84,6 +85,7 @@ describe("voyagerAction", () => {
         (fs.mkdir as any).mockResolvedValue(undefined);
         (fs.writeFile as any).mockResolvedValue(undefined);
         (matter as any).mockReturnValue({ data: {} });
+        vi.mocked(yaml.load as any).mockReset();
         consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
         vi.spyOn(process, "exit").mockImplementation((() => {
             throw new Error("exit");
@@ -211,7 +213,241 @@ describe("voyagerAction", () => {
         expect(withoutSkillsBody.tools).toBeUndefined();
         expect(withoutSkillsBody.tool_choice).toBeUndefined();
     });
+
+    it("loads a valid benchmark pack, skips live setup, and emits pack json", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        vi.mocked(yaml.load as any).mockReturnValue(buildValidPack());
+
+        await voyagerAction(undefined, options, mockCommand);
+
+        expect(resolveCommandScope).not.toHaveBeenCalled();
+        expect(mockConfigManager.loadConfig).not.toHaveBeenCalled();
+        expect(getAgentBerths).not.toHaveBeenCalled();
+        expect(discoverGhosts).not.toHaveBeenCalled();
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls.at(-1)[0]);
+        expect(jsonOutput.kind).toBe("harbor.voyager.benchmark-pack.result");
+        expect(jsonOutput.pass).toBe(true);
+        expect(jsonOutput.totals.scenarios_total).toBe(1);
+    });
+
+    it("saves benchmark pack artifacts with the expected layout", async () => {
+        const options = { file: "pack.yaml", format: "json", saveTrace: true };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        vi.mocked(yaml.load as any).mockReturnValue(buildValidPack());
+
+        await voyagerAction(undefined, options, mockCommand);
+
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("summary.json"), expect.any(String), "utf-8");
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("scenarios/basic-pack-scenario/with-skills.json"), expect.any(String), "utf-8");
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("scenarios/basic-pack-scenario/without-skills.json"), expect.any(String), "utf-8");
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("scenarios/basic-pack-scenario/summary.json"), expect.any(String), "utf-8");
+    });
+
+    it("fails a pack when a scenario fails", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        pack.scenarios[0].assertions.with_skills.assert_status = "failed";
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+    });
+
+    it.each([
+        ["missing kind", (() => { const pack = buildValidPack(); delete pack.kind; return pack; })()],
+        ["wrong kind", (() => { const pack = buildValidPack(); pack.kind = "wrong.kind"; return pack; })()],
+        ["unsupported version", (() => { const pack = buildValidPack(); pack.version = 2; return pack; })()],
+        ["missing pack id", (() => { const pack = buildValidPack(); delete pack.pack.id; return pack; })()],
+        ["invalid scenario id", (() => { const pack = buildValidPack(); pack.scenarios[0].id = "Bad Id"; return pack; })()],
+        ["duplicate scenario ids", (() => { const pack = buildValidPack(); pack.scenarios.push({ ...pack.scenarios[0] }); return pack; })()],
+        ["missing with_skills fixture", (() => { const pack = buildValidPack(); delete pack.scenarios[0].fixtures.with_skills; return pack; })()],
+        ["missing without_skills fixture", (() => { const pack = buildValidPack(); delete pack.scenarios[0].fixtures.without_skills; return pack; })()]
+    ])("fails validation for %s", async (_label, invalidPack) => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        vi.mocked(yaml.load as any).mockReturnValue(invalidPack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+        expect(resolveCommandScope).not.toHaveBeenCalled();
+        expect(mockConfigManager.loadConfig).not.toHaveBeenCalled();
+    });
+
+    it("fails validation when minimum fixture fields are missing", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        delete pack.scenarios[0].fixtures.with_skills.trace_sequence;
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+    });
+
+    it("passes expect_assertion_improved delta assertion when with-skills improves", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        pack.scenarios[0].assertions.delta = { expect_assertion_improved: true };
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await voyagerAction(undefined, options, mockCommand);
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls.at(-1)[0]);
+        expect(jsonOutput.scenarios[0].delta.assertion_improved).toBe(true);
+    });
+
+    it("fails expect_assertion_improved delta assertion when there is no improvement", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        pack.scenarios[0].fixtures.without_skills.status = "completed";
+        pack.scenarios[0].assertions.delta = { expect_assertion_improved: true };
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+    });
+
+    it("passes and fails expect_status_changed delta assertions appropriately", async () => {
+        const passOptions = { file: "pack-pass.yaml", format: "json" };
+        const passCommand = { opts: vi.fn().mockReturnValue(passOptions) };
+        const passingPack = buildValidPack();
+        passingPack.scenarios[0].assertions.delta = { expect_status_changed: true };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(passingPack);
+        await voyagerAction(undefined, passOptions, passCommand);
+
+        const failOptions = { file: "pack-fail.yaml", format: "json" };
+        const failCommand = { opts: vi.fn().mockReturnValue(failOptions) };
+        const failingPack = buildValidPack();
+        failingPack.scenarios[0].fixtures.without_skills.status = "completed";
+        failingPack.scenarios[0].assertions.delta = { expect_status_changed: true };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(failingPack);
+        await expect(voyagerAction(undefined, failOptions, failCommand)).rejects.toThrow("exit");
+    });
+
+    it("passes and fails expect_status_summary delta assertions appropriately", async () => {
+        const passOptions = { file: "pack-pass.yaml", format: "json" };
+        const passCommand = { opts: vi.fn().mockReturnValue(passOptions) };
+        const passingPack = buildValidPack();
+        passingPack.scenarios[0].assertions.delta = { expect_status_summary: "failed -> completed" };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(passingPack);
+        await voyagerAction(undefined, passOptions, passCommand);
+
+        const failOptions = { file: "pack-fail.yaml", format: "json" };
+        const failCommand = { opts: vi.fn().mockReturnValue(failOptions) };
+        const failingPack = buildValidPack();
+        failingPack.scenarios[0].assertions.delta = { expect_status_summary: "completed -> completed" };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(failingPack);
+        await expect(voyagerAction(undefined, failOptions, failCommand)).rejects.toThrow("exit");
+    });
+
+    it("enforces eq/gte/lte comparator assertions for each delta metric", async () => {
+        const comparatorCases = [
+            { label: "tool", field: "expect_tool_count_delta", pass: { eq: 1 }, fail: { eq: 2 } },
+            { label: "iteration", field: "expect_iteration_delta", pass: { gte: 1 }, fail: { lte: 0 } },
+            { label: "elapsed", field: "expect_elapsed_ms_delta", pass: { lte: 80 }, fail: { gte: 100 } }
+        ] as const;
+
+        for (const comparatorCase of comparatorCases) {
+            const passOptions = { file: `pack-pass-${comparatorCase.label}.yaml`, format: "json" };
+            const passCommand = { opts: vi.fn().mockReturnValue(passOptions) };
+            const passingPack = buildValidPack();
+            passingPack.scenarios[0].assertions.delta = { [comparatorCase.field]: comparatorCase.pass };
+            vi.mocked(yaml.load as any).mockReturnValueOnce(passingPack);
+            await voyagerAction(undefined, passOptions, passCommand);
+
+            const failOptions = { file: `pack-fail-${comparatorCase.label}.yaml`, format: "json" };
+            const failCommand = { opts: vi.fn().mockReturnValue(failOptions) };
+            const failingPack = buildValidPack();
+            failingPack.scenarios[0].assertions.delta = { [comparatorCase.field]: comparatorCase.fail };
+            vi.mocked(yaml.load as any).mockReturnValueOnce(failingPack);
+            await expect(voyagerAction(undefined, failOptions, failCommand)).rejects.toThrow("exit");
+        }
+    });
 });
+
+function buildValidPack() {
+    return {
+        kind: "harbor.voyager.benchmark-pack",
+        version: 1,
+        pack: {
+            id: "basic-pack",
+            name: "Basic Pack"
+        },
+        scenarios: [
+            {
+                id: "basic-pack-scenario",
+                name: "Basic Scenario",
+                query: "Check a workflow with and without skills.",
+                fixtures: {
+                    with_skills: makeOfflineFixture({
+                        status: "completed",
+                        final_answer: "done with skills",
+                        iterations: 2,
+                        elapsed_ms: 120,
+                        available_tool_count: 1,
+                        trace_sequence: ["ToolA"],
+                        trace: [
+                            { role: "system", content: "system" },
+                            { role: "user", content: "user" },
+                            { role: "assistant", content: "" },
+                            { role: "tool", toolName: "ToolA", content: "ok" },
+                            { role: "assistant", content: "done with skills" }
+                        ]
+                    }),
+                    without_skills: makeOfflineFixture({
+                        status: "failed",
+                        final_answer: "done without skills",
+                        iterations: 1,
+                        elapsed_ms: 40,
+                        available_tool_count: 0,
+                        trace_sequence: [],
+                        trace: [
+                            { role: "system", content: "system" },
+                            { role: "user", content: "user" },
+                            { role: "assistant", content: "done without skills" }
+                        ]
+                    })
+                },
+                assertions: {
+                    with_skills: {
+                        expected_tools: ["ToolA"],
+                        assert_final_contains: ["done"],
+                        assert_status: "completed"
+                    },
+                    without_skills: {
+                        assert_status: "failed"
+                    },
+                    delta: {
+                        expect_assertion_improved: true,
+                        expect_status_changed: true,
+                        expect_status_summary: "failed -> completed",
+                        expect_tool_count_delta: { eq: 1 },
+                        expect_iteration_delta: { eq: 1 },
+                        expect_elapsed_ms_delta: { eq: 80 }
+                    }
+                }
+            }
+        ]
+    } as any;
+}
+
+function makeOfflineFixture(overrides: any) {
+    return {
+        status: "completed",
+        final_answer: "done",
+        iterations: 1,
+        elapsed_ms: 10,
+        available_tool_count: 0,
+        trace_sequence: [],
+        trace: [
+            { role: "system", content: "system" },
+            { role: "user", content: "user" },
+            { role: "assistant", content: "done" }
+        ],
+        ...overrides
+    };
+}
 
 function makeFetchResponse(message: any) {
     return {

--- a/apps/cli/src/commands/voyager.ts
+++ b/apps/cli/src/commands/voyager.ts
@@ -17,7 +17,15 @@ import {
 } from "../services/ghosts";
 import {
     VoyagerAssertionSummary,
+    VoyagerBenchmarkPackDefinition,
+    VoyagerBenchmarkPackSummary,
+    VoyagerBenchmarkScenarioDefinition,
+    VoyagerBenchmarkScenarioSummary,
+    VoyagerBranchAssertions,
     VoyagerCompareResult,
+    VoyagerDeltaAssertions,
+    VoyagerDeltaComparator,
+    VoyagerOfflineFixtureResult,
     VoyagerRunResult,
     VoyagerTestDefinition,
     VoyagerTraceEvent
@@ -26,6 +34,16 @@ import { printError, printHeader, printSuccess } from "../ui";
 
 const DEFAULT_MOCK_RESPONSE = "Simulated success. Context payload acknowledged.";
 const MAX_ITERATIONS = 10;
+const BENCHMARK_PACK_KIND = "harbor.voyager.benchmark-pack";
+const BENCHMARK_PACK_RESULT_KIND = "harbor.voyager.benchmark-pack.result";
+const SCENARIO_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const OFFLINE_FIXTURE_STATUSES = new Set<VoyagerOfflineFixtureResult["status"]>([
+    "completed",
+    "assertion_failed",
+    "max_iterations",
+    "api_error",
+    "failed"
+]);
 
 type VoyagerTool = {
     type: "function";
@@ -46,6 +64,21 @@ type VoyagerConfig = {
     baseUrl: string;
 };
 
+type VoyagerInputDefinition =
+    | { kind: "legacy"; testDef: VoyagerTestDefinition }
+    | { kind: "benchmark-pack"; packDef: VoyagerBenchmarkPackDefinition; sourcePath: string };
+
+type VoyagerBenchmarkScenarioExecution = {
+    summary: VoyagerBenchmarkScenarioSummary;
+    withSkillsRun: VoyagerRunResult;
+    withoutSkillsRun: VoyagerRunResult;
+};
+
+type VoyagerBenchmarkPackExecution = {
+    summary: VoyagerBenchmarkPackSummary;
+    scenarioExecutions: VoyagerBenchmarkScenarioExecution[];
+};
+
 export async function voyagerAction(queryArg: string | undefined, options: any, command: any) {
     const opts = command.opts();
     const format = opts.format ?? "pretty";
@@ -58,7 +91,34 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
             printHeader("Voyager: Fleet Integration Testing");
         }
 
-        const testDef = await loadVoyagerTestDefinition(queryArg, opts);
+        const input = await loadVoyagerInputDefinition(queryArg, opts);
+        const traceDir = resolveTraceDirectory(opts.saveTrace, input.kind === "benchmark-pack" ? input.packDef.pack.id : undefined);
+
+        if (input.kind === "benchmark-pack") {
+            const result = await runVoyagerBenchmarkPack({
+                packDef: input.packDef,
+                sourcePath: input.sourcePath,
+                pretty,
+                spinnies
+            });
+
+            if (traceDir) {
+                await saveVoyagerPackArtifacts(traceDir, result);
+            }
+
+            if (format === "json") {
+                console.log(JSON.stringify(result.summary, null, 2));
+            } else {
+                printVoyagerBenchmarkPackResult(result.summary, traceDir);
+            }
+
+            if (!result.summary.pass) {
+                process.exit(1);
+            }
+            return;
+        }
+
+        const testDef = input.testDef;
         const manifestManager = getManifestManager({ global: false });
         const { useGlobalScope, shouldStop } = await resolveCommandScope({ global: false }, manifestManager, "skill-harbor voyager");
         if (shouldStop) return;
@@ -150,7 +210,6 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
 
             const result = buildVoyagerCompareResult(testDef, withSkills, withoutSkills);
 
-            const traceDir = resolveTraceDirectory(opts.saveTrace);
             if (traceDir) {
                 await saveVoyagerArtifacts(traceDir, result);
             }
@@ -181,7 +240,6 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
             run
         };
 
-        const traceDir = resolveTraceDirectory(opts.saveTrace);
         if (traceDir) {
             await saveVoyagerArtifacts(traceDir, singlePayload);
         }
@@ -216,26 +274,236 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
     }
 }
 
-async function loadVoyagerTestDefinition(queryArg: string | undefined, opts: any): Promise<VoyagerTestDefinition> {
-    let testDef: VoyagerTestDefinition = { query: queryArg || "" };
-
-    if (opts.file) {
-        const filePath = path.resolve(process.cwd(), opts.file);
-        try {
-            const fileContent = await fs.readFile(filePath, "utf-8");
-            testDef = yaml.load(fileContent) as VoyagerTestDefinition;
-        } catch (err: any) {
-            printError(`Failed to read test definition from ${opts.file}: ${err.message}`);
-            process.exit(1);
-        }
+async function loadVoyagerInputDefinition(queryArg: string | undefined, opts: any): Promise<VoyagerInputDefinition> {
+    if (!opts.file) {
+        const testDef: VoyagerTestDefinition = { query: queryArg || "" };
+        ensureLegacyTestDefinition(testDef);
+        return { kind: "legacy", testDef };
     }
 
+    const filePath = path.resolve(process.cwd(), opts.file);
+    try {
+        const fileContent = await fs.readFile(filePath, "utf-8");
+        const parsed = yaml.load(fileContent) as unknown;
+
+        if (looksLikeBenchmarkPack(parsed)) {
+            return {
+                kind: "benchmark-pack",
+                packDef: validateBenchmarkPackDefinition(parsed),
+                sourcePath: filePath
+            };
+        }
+
+        const testDef = parsed as VoyagerTestDefinition;
+        ensureLegacyTestDefinition(testDef);
+        return { kind: "legacy", testDef };
+    } catch (err: any) {
+        printError(`Failed to read test definition from ${opts.file}: ${err.message}`);
+        process.exit(1);
+    }
+}
+
+function ensureLegacyTestDefinition(testDef: VoyagerTestDefinition) {
     if (!testDef.query) {
         printError("You must provide either an inline [query] or a -f/--file definition with a 'query' field.");
         process.exit(1);
     }
+}
 
-    return testDef;
+function looksLikeBenchmarkPack(value: unknown): boolean {
+    return isRecord(value) && (
+        "kind" in value
+        || "version" in value
+        || "pack" in value
+        || "scenarios" in value
+    );
+}
+
+function validateBenchmarkPackDefinition(value: unknown): VoyagerBenchmarkPackDefinition {
+    if (!isRecord(value)) {
+        throw new Error("Benchmark pack root must be an object.");
+    }
+
+    if (value.kind === undefined) {
+        throw new Error("Benchmark pack is missing required 'kind'.");
+    }
+    if (value.kind !== BENCHMARK_PACK_KIND) {
+        throw new Error(`Unsupported benchmark pack kind '${String(value.kind)}'. Expected '${BENCHMARK_PACK_KIND}'.`);
+    }
+    if (value.version !== 1) {
+        throw new Error(`Unsupported benchmark pack version '${String(value.version)}'. Expected 1.`);
+    }
+    if (!isRecord(value.pack)) {
+        throw new Error("Benchmark pack is missing required 'pack' object.");
+    }
+
+    const packId = value.pack.id;
+    if (typeof packId !== "string" || !SCENARIO_ID_PATTERN.test(packId)) {
+        throw new Error("Benchmark pack requires a slug-valid 'pack.id'.");
+    }
+
+    if (!Array.isArray(value.scenarios) || value.scenarios.length === 0) {
+        throw new Error("Benchmark pack requires a non-empty 'scenarios' array.");
+    }
+
+    const seenScenarioIds = new Set<string>();
+    const scenarios = value.scenarios.map((scenario, index) => validateBenchmarkScenario(scenario, index, seenScenarioIds));
+
+    return {
+        kind: BENCHMARK_PACK_KIND,
+        version: 1,
+        pack: {
+            id: packId,
+            name: typeof value.pack.name === "string" ? value.pack.name : undefined,
+            description: typeof value.pack.description === "string" ? value.pack.description : undefined,
+            tags: Array.isArray(value.pack.tags) ? value.pack.tags.filter((tag): tag is string => typeof tag === "string") : undefined
+        },
+        scenarios
+    };
+}
+
+function validateBenchmarkScenario(value: unknown, index: number, seenScenarioIds: Set<string>): VoyagerBenchmarkScenarioDefinition {
+    if (!isRecord(value)) {
+        throw new Error(`Scenario at index ${index} must be an object.`);
+    }
+
+    if (typeof value.id !== "string" || !SCENARIO_ID_PATTERN.test(value.id)) {
+        throw new Error(`Scenario at index ${index} requires a slug-valid 'id'.`);
+    }
+    if (seenScenarioIds.has(value.id)) {
+        throw new Error(`Duplicate scenario id '${value.id}'.`);
+    }
+    seenScenarioIds.add(value.id);
+
+    if (typeof value.query !== "string" || value.query.length === 0) {
+        throw new Error(`Scenario '${value.id}' requires a non-empty 'query'.`);
+    }
+    if (!isRecord(value.fixtures)) {
+        throw new Error(`Scenario '${value.id}' requires a 'fixtures' object.`);
+    }
+    if (!isRecord(value.fixtures.with_skills)) {
+        throw new Error(`Scenario '${value.id}' is missing required 'fixtures.with_skills'.`);
+    }
+    if (!isRecord(value.fixtures.without_skills)) {
+        throw new Error(`Scenario '${value.id}' is missing required 'fixtures.without_skills'.`);
+    }
+
+    return {
+        id: value.id,
+        name: typeof value.name === "string" ? value.name : undefined,
+        query: value.query,
+        tags: Array.isArray(value.tags) ? value.tags.filter((tag): tag is string => typeof tag === "string") : undefined,
+        fixtures: {
+            with_skills: validateOfflineFixture(value.fixtures.with_skills, value.id, "with_skills"),
+            without_skills: validateOfflineFixture(value.fixtures.without_skills, value.id, "without_skills")
+        },
+        assertions: validateScenarioAssertions(value.assertions)
+    };
+}
+
+function validateScenarioAssertions(value: unknown): VoyagerBenchmarkScenarioDefinition["assertions"] | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Scenario assertions must be an object when provided.");
+    }
+
+    return {
+        with_skills: validateBranchAssertions(value.with_skills),
+        without_skills: validateBranchAssertions(value.without_skills),
+        delta: validateDeltaAssertions(value.delta)
+    };
+}
+
+function validateBranchAssertions(value: unknown): VoyagerBranchAssertions | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Scenario branch assertions must be an object when provided.");
+    }
+
+    return {
+        expected_tools: Array.isArray(value.expected_tools)
+            ? value.expected_tools.filter((entry): entry is string => typeof entry === "string")
+            : undefined,
+        assert_final_contains: Array.isArray(value.assert_final_contains)
+            ? value.assert_final_contains.filter((entry): entry is string => typeof entry === "string")
+            : undefined,
+        assert_status: value.assert_status === "completed" || value.assert_status === "failed"
+            ? value.assert_status
+            : undefined
+    };
+}
+
+function validateDeltaAssertions(value: unknown): VoyagerDeltaAssertions | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Scenario delta assertions must be an object when provided.");
+    }
+
+    return {
+        expect_assertion_improved: typeof value.expect_assertion_improved === "boolean" ? value.expect_assertion_improved : undefined,
+        expect_status_changed: typeof value.expect_status_changed === "boolean" ? value.expect_status_changed : undefined,
+        expect_status_summary: typeof value.expect_status_summary === "string" ? value.expect_status_summary : undefined,
+        expect_tool_count_delta: validateDeltaComparator(value.expect_tool_count_delta),
+        expect_iteration_delta: validateDeltaComparator(value.expect_iteration_delta),
+        expect_elapsed_ms_delta: validateDeltaComparator(value.expect_elapsed_ms_delta)
+    };
+}
+
+function validateDeltaComparator(value: unknown): VoyagerDeltaComparator | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Delta comparator must be an object when provided.");
+    }
+
+    const comparator: VoyagerDeltaComparator = {};
+    if (typeof value.eq === "number") comparator.eq = value.eq;
+    if (typeof value.gte === "number") comparator.gte = value.gte;
+    if (typeof value.lte === "number") comparator.lte = value.lte;
+    return Object.keys(comparator).length > 0 ? comparator : undefined;
+}
+
+function validateOfflineFixture(value: unknown, scenarioId: string, label: "with_skills" | "without_skills"): VoyagerOfflineFixtureResult {
+    if (!isRecord(value)) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' must be an object.`);
+    }
+
+    if (typeof value.status !== "string" || !OFFLINE_FIXTURE_STATUSES.has(value.status as VoyagerOfflineFixtureResult["status"])) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires a valid 'status'.`);
+    }
+    if (typeof value.final_answer !== "string") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires 'final_answer'.`);
+    }
+    if (typeof value.iterations !== "number") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires numeric 'iterations'.`);
+    }
+    if (typeof value.elapsed_ms !== "number") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires numeric 'elapsed_ms'.`);
+    }
+    if (typeof value.available_tool_count !== "number") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires numeric 'available_tool_count'.`);
+    }
+    if (!Array.isArray(value.trace_sequence) || !value.trace_sequence.every((entry: unknown) => typeof entry === "string")) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires string-array 'trace_sequence'.`);
+    }
+    if (!Array.isArray(value.trace) || !value.trace.every(isVoyagerOfflineTraceEvent)) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires valid 'trace' entries.`);
+    }
+
+    return {
+        status: value.status as VoyagerOfflineFixtureResult["status"],
+        final_answer: value.final_answer,
+        iterations: value.iterations,
+        elapsed_ms: value.elapsed_ms,
+        available_tool_count: value.available_tool_count,
+        trace_sequence: value.trace_sequence,
+        trace: value.trace,
+        error: typeof value.error === "string" ? value.error : undefined
+    };
+}
+
+function isVoyagerOfflineTraceEvent(value: unknown): boolean {
+    if (!isRecord(value)) return false;
+    return typeof value.role === "string" && typeof value.content === "string";
 }
 
 async function discoverVoyagerTools(activeBerths: Array<{ path: string }>, profiler: ProfilerService): Promise<VoyagerTool[]> {
@@ -453,40 +721,7 @@ async function runVoyagerScenario({
         break;
     }
 
-    const assertions = evaluateVoyagerAssertions(
-        {
-            label,
-            status,
-            finalAnswer,
-            iterations: iteration,
-            elapsedMs: Date.now() - startedAt,
-            availableToolCount: tools.length,
-            toolCallCount: traceSequence.length,
-            traceSequence,
-            trace,
-            assertions: {
-                allPassed: true,
-                missingExpectedTools: [],
-                missingFinalContains: []
-            },
-            error
-        },
-        testDef
-    );
-
-    if (status === "completed" && !assertions.allPassed) {
-        status = "assertion_failed";
-    }
-
-    if (pretty) {
-        if (status === "completed" || status === "assertion_failed") {
-            spinnies.succeed(spinnerId, { text: `${kleur.green(label)} run complete.` });
-        } else {
-            spinnies.fail(spinnerId, { text: `${kleur.red(label)} run failed.` });
-        }
-    }
-
-    return {
+    const assertions = evaluateVoyagerBranchAssertions(runSkeleton({
         label,
         status,
         finalAnswer,
@@ -496,20 +731,170 @@ async function runVoyagerScenario({
         toolCallCount: traceSequence.length,
         traceSequence,
         trace,
-        assertions,
         error
+    }), {
+        expected_tools: testDef.expected_tools,
+        assert_final_contains: testDef.assert_final_contains,
+        assert_status: testDef.assert_status
+    });
+
+    if (status === "completed" && !assertions.allPassed) {
+        status = "assertion_failed";
+    }
+
+    const run = runSkeleton({
+        label,
+        status,
+        finalAnswer,
+        iterations: iteration,
+        elapsedMs: Date.now() - startedAt,
+        availableToolCount: tools.length,
+        toolCallCount: traceSequence.length,
+        traceSequence,
+        trace,
+        error
+    }, assertions);
+
+    if (pretty) {
+        if (status === "completed" || status === "assertion_failed") {
+            spinnies.succeed(spinnerId, { text: `${kleur.green(label)} run complete.` });
+        } else {
+            spinnies.fail(spinnerId, { text: `${kleur.red(label)} run failed.` });
+        }
+    }
+
+    return run;
+}
+
+async function runVoyagerBenchmarkPack({
+    packDef,
+    sourcePath,
+    pretty,
+    spinnies
+}: {
+    packDef: VoyagerBenchmarkPackDefinition;
+    sourcePath: string;
+    pretty: boolean;
+    spinnies: Spinnies;
+}): Promise<VoyagerBenchmarkPackExecution> {
+    const spinnerId = `voyager-pack-${packDef.pack.id}`;
+    if (pretty) {
+        spinnies.add(spinnerId, { text: `Running benchmark pack ${kleur.bold(packDef.pack.id)}...` });
+    }
+
+    const scenarioExecutions: VoyagerBenchmarkScenarioExecution[] = [];
+
+    for (const scenario of packDef.scenarios) {
+        const withSkillsRun = buildOfflineRunFromFixture("with-skills", scenario.fixtures.with_skills);
+        const withoutSkillsRun = buildOfflineRunFromFixture("without-skills", scenario.fixtures.without_skills);
+
+        const withSkillsAssertions = evaluateVoyagerBranchAssertions(withSkillsRun, scenario.assertions?.with_skills);
+        const withoutSkillsAssertions = evaluateVoyagerBranchAssertions(withoutSkillsRun, scenario.assertions?.without_skills);
+
+        const finalWithSkillsRun = finalizeOfflineRun(withSkillsRun, withSkillsAssertions);
+        const finalWithoutSkillsRun = finalizeOfflineRun(withoutSkillsRun, withoutSkillsAssertions);
+        const delta = buildVoyagerPackDelta(finalWithSkillsRun, finalWithoutSkillsRun);
+        const deltaEvaluation = evaluateVoyagerDeltaAssertions(delta, scenario.assertions?.delta);
+        const scenarioFailures = collectScenarioFailures(withSkillsAssertions, withoutSkillsAssertions, deltaEvaluation.failures);
+        const scenarioPassed = withSkillsAssertions.allPassed && withoutSkillsAssertions.allPassed && deltaEvaluation.allPassed;
+
+        scenarioExecutions.push({
+            withSkillsRun: finalWithSkillsRun,
+            withoutSkillsRun: finalWithoutSkillsRun,
+            summary: {
+                id: scenario.id,
+                name: scenario.name,
+                path: path.join("scenarios", scenario.id, "summary.json"),
+                status: scenarioPassed ? "passed" : "failed",
+                with_skills: {
+                    status: toPackConditionStatus(finalWithSkillsRun.status),
+                    assertions_passed: withSkillsAssertions.allPassed,
+                    tool_call_count: finalWithSkillsRun.toolCallCount
+                },
+                without_skills: {
+                    status: toPackConditionStatus(finalWithoutSkillsRun.status),
+                    assertions_passed: withoutSkillsAssertions.allPassed,
+                    tool_call_count: finalWithoutSkillsRun.toolCallCount
+                },
+                delta: {
+                    ...delta,
+                    expectations_passed: deltaEvaluation.allPassed
+                },
+                failures: scenarioFailures
+            }
+        });
+    }
+
+    const summary = buildVoyagerBenchmarkPackSummary(packDef, sourcePath, scenarioExecutions);
+
+    if (pretty) {
+        if (summary.pass) {
+            spinnies.succeed(spinnerId, { text: `Benchmark pack ${kleur.green(packDef.pack.id)} complete.` });
+        } else {
+            spinnies.fail(spinnerId, { text: `Benchmark pack ${kleur.red(packDef.pack.id)} failed.` });
+        }
+    }
+
+    return {
+        summary,
+        scenarioExecutions
     };
 }
 
-function evaluateVoyagerAssertions(run: VoyagerRunResult, testDef: VoyagerTestDefinition): VoyagerAssertionSummary {
+function buildOfflineRunFromFixture(label: string, fixture: VoyagerOfflineFixtureResult): VoyagerRunResult {
+    const trace = fixture.trace.map((entry, index) => ({
+        role: entry.role,
+        content: entry.content,
+        toolName: entry.toolName,
+        toolCallId: entry.toolCallId,
+        timestamp: entry.timestamp ?? new Date(Date.now() + index).toISOString()
+    }));
+
+    return runSkeleton({
+        label,
+        status: fixture.status === "failed" ? "assertion_failed" : fixture.status,
+        finalAnswer: fixture.final_answer,
+        iterations: fixture.iterations,
+        elapsedMs: fixture.elapsed_ms,
+        availableToolCount: fixture.available_tool_count,
+        toolCallCount: fixture.trace_sequence.length,
+        traceSequence: [...fixture.trace_sequence],
+        trace,
+        error: fixture.error
+    });
+}
+
+function finalizeOfflineRun(run: VoyagerRunResult, assertions: VoyagerAssertionSummary): VoyagerRunResult {
+    const status = run.status === "completed" && !assertions.allPassed
+        ? "assertion_failed"
+        : run.status;
+
+    return runSkeleton({
+        ...run,
+        status
+    }, assertions);
+}
+
+function runSkeleton(run: Omit<VoyagerRunResult, "assertions">, assertions?: VoyagerAssertionSummary): VoyagerRunResult {
+    return {
+        ...run,
+        assertions: assertions ?? {
+            allPassed: true,
+            missingExpectedTools: [],
+            missingFinalContains: []
+        }
+    };
+}
+
+function evaluateVoyagerBranchAssertions(run: VoyagerRunResult, assertions?: VoyagerBranchAssertions): VoyagerAssertionSummary {
     const missingExpectedTools: string[] = [];
     const missingFinalContains: string[] = [];
 
     let expectedToolsPassed: boolean | undefined;
-    if (testDef.expected_tools && testDef.expected_tools.length > 0) {
+    if (assertions?.expected_tools && assertions.expected_tools.length > 0) {
         expectedToolsPassed = true;
         let traceIdx = 0;
-        for (const expected of testDef.expected_tools) {
+        for (const expected of assertions.expected_tools) {
             const foundIdx = run.traceSequence.indexOf(expected, traceIdx);
             if (foundIdx === -1) {
                 expectedToolsPassed = false;
@@ -521,9 +906,9 @@ function evaluateVoyagerAssertions(run: VoyagerRunResult, testDef: VoyagerTestDe
     }
 
     let finalContainsPassed: boolean | undefined;
-    if (testDef.assert_final_contains && testDef.assert_final_contains.length > 0) {
+    if (assertions?.assert_final_contains && assertions.assert_final_contains.length > 0) {
         finalContainsPassed = true;
-        for (const fragment of testDef.assert_final_contains) {
+        for (const fragment of assertions.assert_final_contains) {
             if (!run.finalAnswer.includes(fragment)) {
                 finalContainsPassed = false;
                 missingFinalContains.push(fragment);
@@ -532,9 +917,8 @@ function evaluateVoyagerAssertions(run: VoyagerRunResult, testDef: VoyagerTestDe
     }
 
     let statusPassed: boolean | undefined;
-    if (testDef.assert_status) {
-        const normalizedStatus = run.status === "completed" ? "completed" : "failed";
-        statusPassed = normalizedStatus === testDef.assert_status;
+    if (assertions?.assert_status) {
+        statusPassed = toPackConditionStatus(run.status) === assertions.assert_status;
     }
 
     const allPassed = [expectedToolsPassed, finalContainsPassed, statusPassed].every(value => value !== false);
@@ -562,16 +946,165 @@ function buildVoyagerCompareResult(
         },
         with_skills: withSkills,
         without_skills: withoutSkills,
-        delta: {
-            status_changed: withSkills.status !== withoutSkills.status,
-            status_summary: `${withoutSkills.status} -> ${withSkills.status}`,
-            assertion_improved: Number(withSkills.assertions.allPassed) > Number(withoutSkills.assertions.allPassed),
-            iteration_delta: withSkills.iterations - withoutSkills.iterations,
-            elapsed_ms_delta: withSkills.elapsedMs - withoutSkills.elapsedMs,
-            tool_count_delta: withSkills.toolCallCount - withoutSkills.toolCallCount,
-            skills_used_delta: withSkills.availableToolCount - withoutSkills.availableToolCount
-        }
+        delta: buildVoyagerCompareDelta(withSkills, withoutSkills)
     };
+}
+
+function buildVoyagerCompareDelta(withSkills: VoyagerRunResult, withoutSkills: VoyagerRunResult): VoyagerCompareResult["delta"] {
+    return {
+        status_changed: withSkills.status !== withoutSkills.status,
+        status_summary: `${withoutSkills.status} -> ${withSkills.status}`,
+        assertion_improved: Number(withSkills.assertions.allPassed) > Number(withoutSkills.assertions.allPassed),
+        iteration_delta: withSkills.iterations - withoutSkills.iterations,
+        elapsed_ms_delta: withSkills.elapsedMs - withoutSkills.elapsedMs,
+        tool_count_delta: withSkills.toolCallCount - withoutSkills.toolCallCount,
+        skills_used_delta: withSkills.availableToolCount - withoutSkills.availableToolCount
+    };
+}
+
+function buildVoyagerPackDelta(withSkills: VoyagerRunResult, withoutSkills: VoyagerRunResult): VoyagerCompareResult["delta"] {
+    const withSkillsStatus = toPackConditionStatus(withSkills.status);
+    const withoutSkillsStatus = toPackConditionStatus(withoutSkills.status);
+    const assertionImproved = Number(withSkills.assertions.allPassed) > Number(withoutSkills.assertions.allPassed)
+        || (withSkillsStatus === "completed" && withoutSkillsStatus === "failed");
+
+    return {
+        status_changed: withSkillsStatus !== withoutSkillsStatus,
+        status_summary: `${withoutSkillsStatus} -> ${withSkillsStatus}`,
+        assertion_improved: assertionImproved,
+        iteration_delta: withSkills.iterations - withoutSkills.iterations,
+        elapsed_ms_delta: withSkills.elapsedMs - withoutSkills.elapsedMs,
+        tool_count_delta: withSkills.toolCallCount - withoutSkills.toolCallCount,
+        skills_used_delta: withSkills.availableToolCount - withoutSkills.availableToolCount
+    };
+}
+
+function evaluateVoyagerDeltaAssertions(delta: VoyagerCompareResult["delta"], assertions?: VoyagerDeltaAssertions): { allPassed: boolean; failures: string[] } {
+    if (!assertions) {
+        return { allPassed: true, failures: [] };
+    }
+
+    const failures: string[] = [];
+
+    if (assertions.expect_assertion_improved !== undefined && delta.assertion_improved !== assertions.expect_assertion_improved) {
+        failures.push(`Expected assertion_improved=${assertions.expect_assertion_improved} but received ${delta.assertion_improved}.`);
+    }
+    if (assertions.expect_status_changed !== undefined && delta.status_changed !== assertions.expect_status_changed) {
+        failures.push(`Expected status_changed=${assertions.expect_status_changed} but received ${delta.status_changed}.`);
+    }
+    if (assertions.expect_status_summary !== undefined && delta.status_summary !== assertions.expect_status_summary) {
+        failures.push(`Expected status_summary='${assertions.expect_status_summary}' but received '${delta.status_summary}'.`);
+    }
+
+    evaluateComparatorFailures("tool_count_delta", delta.tool_count_delta, assertions.expect_tool_count_delta, failures);
+    evaluateComparatorFailures("iteration_delta", delta.iteration_delta, assertions.expect_iteration_delta, failures);
+    evaluateComparatorFailures("elapsed_ms_delta", delta.elapsed_ms_delta, assertions.expect_elapsed_ms_delta, failures);
+
+    return {
+        allPassed: failures.length === 0,
+        failures
+    };
+}
+
+function evaluateComparatorFailures(
+    label: string,
+    value: number,
+    comparator: VoyagerDeltaComparator | undefined,
+    failures: string[]
+) {
+    if (!comparator) return;
+    if (comparator.eq !== undefined && value !== comparator.eq) {
+        failures.push(`Expected ${label} == ${comparator.eq} but received ${value}.`);
+    }
+    if (comparator.gte !== undefined && value < comparator.gte) {
+        failures.push(`Expected ${label} >= ${comparator.gte} but received ${value}.`);
+    }
+    if (comparator.lte !== undefined && value > comparator.lte) {
+        failures.push(`Expected ${label} <= ${comparator.lte} but received ${value}.`);
+    }
+}
+
+function collectScenarioFailures(
+    withSkills: VoyagerAssertionSummary,
+    withoutSkills: VoyagerAssertionSummary,
+    deltaFailures: string[]
+): string[] {
+    const failures: string[] = [];
+
+    if (withSkills.expectedToolsPassed === false) {
+        failures.push(`with_skills missing expected tools: ${withSkills.missingExpectedTools.join(", ")}`);
+    }
+    if (withSkills.finalContainsPassed === false) {
+        failures.push(`with_skills missing output fragments: ${withSkills.missingFinalContains.join(", ")}`);
+    }
+    if (withSkills.statusPassed === false) {
+        failures.push("with_skills status assertion failed.");
+    }
+
+    if (withoutSkills.expectedToolsPassed === false) {
+        failures.push(`without_skills missing expected tools: ${withoutSkills.missingExpectedTools.join(", ")}`);
+    }
+    if (withoutSkills.finalContainsPassed === false) {
+        failures.push(`without_skills missing output fragments: ${withoutSkills.missingFinalContains.join(", ")}`);
+    }
+    if (withoutSkills.statusPassed === false) {
+        failures.push("without_skills status assertion failed.");
+    }
+
+    failures.push(...deltaFailures);
+    return failures;
+}
+
+function buildVoyagerBenchmarkPackSummary(
+    packDef: VoyagerBenchmarkPackDefinition,
+    sourcePath: string,
+    executions: VoyagerBenchmarkScenarioExecution[]
+): VoyagerBenchmarkPackSummary {
+    const scenariosPassed = executions.filter(execution => execution.summary.status === "passed").length;
+    const scenariosFailed = executions.length - scenariosPassed;
+
+    const conditionsPassed = executions.reduce((sum, execution) => {
+        return sum
+            + Number(execution.summary.with_skills.assertions_passed)
+            + Number(execution.summary.without_skills.assertions_passed);
+    }, 0);
+
+    const deltaImproved = executions.filter(execution => execution.summary.delta.assertion_improved).length;
+    const deltaNeutral = executions.filter(execution => isNeutralDelta(execution.summary.delta)).length;
+    const deltaRegressed = executions.length - deltaImproved - deltaNeutral;
+
+    return {
+        kind: BENCHMARK_PACK_RESULT_KIND,
+        version: 1,
+        pack: {
+            id: packDef.pack.id,
+            name: packDef.pack.name,
+            source: sourcePath,
+            mode: "offline-fixture",
+            generated_at: new Date().toISOString()
+        },
+        totals: {
+            scenarios_total: executions.length,
+            scenarios_passed: scenariosPassed,
+            scenarios_failed: scenariosFailed,
+            conditions_total: executions.length * 2,
+            conditions_passed: conditionsPassed,
+            conditions_failed: executions.length * 2 - conditionsPassed,
+            delta_improved: deltaImproved,
+            delta_neutral: deltaNeutral,
+            delta_regressed: deltaRegressed
+        },
+        pass: scenariosFailed === 0,
+        scenarios: executions.map(execution => execution.summary)
+    };
+}
+
+function isNeutralDelta(delta: VoyagerBenchmarkScenarioSummary["delta"]): boolean {
+    return !delta.assertion_improved
+        && !delta.status_changed
+        && delta.iteration_delta === 0
+        && delta.elapsed_ms_delta === 0
+        && delta.tool_count_delta === 0;
 }
 
 function printVoyagerSingleResult(run: VoyagerRunResult, traceDir?: string) {
@@ -617,6 +1150,28 @@ function printVoyagerCompareResult(result: VoyagerCompareResult, traceDir?: stri
     }
 }
 
+function printVoyagerBenchmarkPackResult(result: VoyagerBenchmarkPackSummary, traceDir?: string) {
+    console.log(kleur.bold("Benchmark Pack Summary"));
+    console.log(`${kleur.gray("Pack:")} ${kleur.white(result.pack.name || result.pack.id)}`);
+    console.log(`${kleur.gray("Pass:")} ${result.pass ? kleur.green("yes") : kleur.red("no")}`);
+    console.log(`${kleur.gray("Scenarios:")} ${result.totals.scenarios_passed}/${result.totals.scenarios_total} passed`);
+
+    for (const scenario of result.scenarios) {
+        console.log(`\n${kleur.bold(scenario.id)} ${scenario.status === "passed" ? kleur.green("passed") : kleur.red("failed")}`);
+        console.log(`  ${kleur.gray("Status delta:")} ${scenario.delta.status_summary}`);
+        console.log(`  ${kleur.gray("Assertion improved:")} ${scenario.delta.assertion_improved ? "yes" : "no"}`);
+        if (scenario.failures.length > 0) {
+            for (const failure of scenario.failures) {
+                console.log(`  ${kleur.red("✗")} ${failure}`);
+            }
+        }
+    }
+
+    if (traceDir) {
+        console.log(`\n${kleur.gray("Saved trace artifacts:")} ${kleur.cyan(traceDir)}`);
+    }
+}
+
 function printAssertionSummary(assertions: VoyagerAssertionSummary, indent = "") {
     if (assertions.expectedToolsPassed !== undefined) {
         if (assertions.expectedToolsPassed) {
@@ -639,7 +1194,7 @@ function printAssertionSummary(assertions: VoyagerAssertionSummary, indent = "")
     }
 }
 
-function resolveTraceDirectory(saveTrace?: string | boolean): string | undefined {
+function resolveTraceDirectory(saveTrace?: string | boolean, packId?: string): string | undefined {
     if (!saveTrace) return undefined;
 
     if (typeof saveTrace === "string") {
@@ -647,7 +1202,8 @@ function resolveTraceDirectory(saveTrace?: string | boolean): string | undefined
     }
 
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    return path.join(process.cwd(), ".harbor", "voyager-runs", stamp);
+    const suffix = packId ? `-${packId}` : "";
+    return path.join(process.cwd(), ".harbor", "voyager-runs", `${stamp}${suffix}`);
 }
 
 async function saveVoyagerArtifacts(traceDir: string, payload: unknown) {
@@ -665,8 +1221,25 @@ async function saveVoyagerArtifacts(traceDir: string, payload: unknown) {
     await fs.writeFile(path.join(traceDir, "summary.json"), JSON.stringify(payload, null, 2), "utf-8");
 }
 
+async function saveVoyagerPackArtifacts(traceDir: string, payload: VoyagerBenchmarkPackExecution) {
+    await fs.mkdir(traceDir, { recursive: true });
+    await fs.writeFile(path.join(traceDir, "summary.json"), JSON.stringify(payload.summary, null, 2), "utf-8");
+
+    for (const execution of payload.scenarioExecutions) {
+        const scenarioDir = path.join(traceDir, "scenarios", execution.summary.id);
+        await fs.mkdir(scenarioDir, { recursive: true });
+        await fs.writeFile(path.join(scenarioDir, "with-skills.json"), JSON.stringify(execution.withSkillsRun, null, 2), "utf-8");
+        await fs.writeFile(path.join(scenarioDir, "without-skills.json"), JSON.stringify(execution.withoutSkillsRun, null, 2), "utf-8");
+        await fs.writeFile(path.join(scenarioDir, "summary.json"), JSON.stringify(execution.summary, null, 2), "utf-8");
+    }
+}
+
 function isComparePayload(payload: unknown): payload is VoyagerCompareResult {
     return Boolean(payload && typeof payload === "object" && "with_skills" in payload && "without_skills" in payload);
+}
+
+function toPackConditionStatus(status: VoyagerRunResult["status"]): "completed" | "failed" {
+    return status === "completed" ? "completed" : "failed";
 }
 
 function createTraceEvent(
@@ -682,4 +1255,8 @@ function createTraceEvent(
         toolCallId,
         timestamp: new Date().toISOString()
     };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/apps/cli/src/types/voyager.ts
+++ b/apps/cli/src/types/voyager.ts
@@ -16,6 +16,27 @@ export interface VoyagerTestDefinition {
     assert_status?: "completed" | "failed";
 }
 
+export interface VoyagerBranchAssertions {
+    expected_tools?: string[];
+    assert_final_contains?: string[];
+    assert_status?: "completed" | "failed";
+}
+
+export interface VoyagerDeltaComparator {
+    eq?: number;
+    gte?: number;
+    lte?: number;
+}
+
+export interface VoyagerDeltaAssertions {
+    expect_assertion_improved?: boolean;
+    expect_status_changed?: boolean;
+    expect_status_summary?: string;
+    expect_tool_count_delta?: VoyagerDeltaComparator;
+    expect_iteration_delta?: VoyagerDeltaComparator;
+    expect_elapsed_ms_delta?: VoyagerDeltaComparator;
+}
+
 export type VoyagerRunStatus = "completed" | "assertion_failed" | "max_iterations" | "api_error";
 
 export interface VoyagerTraceEvent {
@@ -24,6 +45,27 @@ export interface VoyagerTraceEvent {
     toolName?: string;
     toolCallId?: string;
     timestamp: string;
+}
+
+export interface VoyagerOfflineTraceEvent {
+    role: VoyagerTraceEvent["role"];
+    content: string;
+    toolName?: string;
+    toolCallId?: string;
+    timestamp?: string;
+}
+
+export type VoyagerOfflineFixtureStatus = VoyagerRunStatus | "failed";
+
+export interface VoyagerOfflineFixtureResult {
+    status: VoyagerOfflineFixtureStatus;
+    final_answer: string;
+    iterations: number;
+    elapsed_ms: number;
+    available_tool_count: number;
+    trace_sequence: string[];
+    trace: VoyagerOfflineTraceEvent[];
+    error?: string;
 }
 
 export interface VoyagerAssertionSummary {
@@ -66,4 +108,78 @@ export interface VoyagerCompareResult {
         tool_count_delta: number;
         skills_used_delta: number;
     };
+}
+
+export interface VoyagerBenchmarkScenarioDefinition {
+    id: string;
+    name?: string;
+    query: string;
+    tags?: string[];
+    fixtures: {
+        with_skills: VoyagerOfflineFixtureResult;
+        without_skills: VoyagerOfflineFixtureResult;
+    };
+    assertions?: {
+        with_skills?: VoyagerBranchAssertions;
+        without_skills?: VoyagerBranchAssertions;
+        delta?: VoyagerDeltaAssertions;
+    };
+}
+
+export interface VoyagerBenchmarkPackDefinition {
+    kind: "harbor.voyager.benchmark-pack";
+    version: 1;
+    pack: {
+        id: string;
+        name?: string;
+        description?: string;
+        tags?: string[];
+    };
+    scenarios: VoyagerBenchmarkScenarioDefinition[];
+}
+
+export interface VoyagerBenchmarkScenarioSummary {
+    id: string;
+    name?: string;
+    path?: string;
+    status: "passed" | "failed";
+    with_skills: {
+        status: "completed" | "failed";
+        assertions_passed: boolean;
+        tool_call_count: number;
+    };
+    without_skills: {
+        status: "completed" | "failed";
+        assertions_passed: boolean;
+        tool_call_count: number;
+    };
+    delta: VoyagerCompareResult["delta"] & {
+        expectations_passed: boolean;
+    };
+    failures: string[];
+}
+
+export interface VoyagerBenchmarkPackSummary {
+    kind: "harbor.voyager.benchmark-pack.result";
+    version: 1;
+    pack: {
+        id: string;
+        name?: string;
+        source: string;
+        mode: "offline-fixture";
+        generated_at: string;
+    };
+    totals: {
+        scenarios_total: number;
+        scenarios_passed: number;
+        scenarios_failed: number;
+        conditions_total: number;
+        conditions_passed: number;
+        conditions_failed: number;
+        delta_improved: number;
+        delta_neutral: number;
+        delta_regressed: number;
+    };
+    pass: boolean;
+    scenarios: VoyagerBenchmarkScenarioSummary[];
 }

--- a/docs/benchmarking/meta.json
+++ b/docs/benchmarking/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Benchmarking",
+  "pages": [
+    "overview",
+    "voyager-vs-fathom"
+  ]
+}

--- a/docs/benchmarking/overview.mdx
+++ b/docs/benchmarking/overview.mdx
@@ -1,0 +1,114 @@
+---
+title: "Benchmarking Overview"
+description: "How Skill Harbor approaches benchmarking, evaluation, and what it contributes beyond raw benchmark execution."
+icon: "chart-line"
+---
+
+# 📊 Benchmarking in Skill Harbor
+
+Skill Harbor is **not** trying to become a public leaderboard or replace benchmark projects like SkillsBench.
+
+Instead, Skill Harbor treats benchmarking as an **operational capability** inside a team workflow:
+
+- define what should be evaluated
+- run those evaluations repeatably
+- keep the evaluated skill set governed and portable
+- use the results to improve what the team actually ships
+
+That is the core difference.
+
+## The basic idea
+
+A benchmark is only useful if it can survive contact with a real team:
+
+- the skill set must be known
+- the evaluated context must be reproducible
+- the results must be inspectable later
+- the benchmark should fit local development and CI, not only a research harness
+
+Skill Harbor's role is to make those conditions true.
+
+## What Skill Harbor brings
+
+### 1. Governed evaluation inputs
+
+Before you benchmark anything, you need to know **which skills are actually in play**.
+
+Skill Harbor gives you:
+- a manifest-driven source of truth
+- provenance for skill sources
+- consistent berthing across supported agent targets
+- fleet-level inspection and validation
+
+That means benchmarking is attached to a **known fleet**, not an ad hoc pile of prompt files.
+
+### 2. Reproducible scenario evaluation
+
+Skill Harbor's contribution is not merely “run a benchmark.”
+It is to make evaluation:
+
+- **local-first**
+- **CI-friendly**
+- **portable**
+- **artifact-producing**
+
+That is why Voyager now grows toward **Harbor-native benchmark packs** instead of depending immediately on an external task format.
+
+### 3. Clear separation between measurement and prediction
+
+Skill Harbor intentionally separates two different questions:
+
+1. **What happened on a scenario?**
+2. **What is this fleet likely to help or hurt?**
+
+Those belong to different surfaces:
+
+- **Voyager** answers the first question through scenario execution and result comparison.
+- **Fathom** answers the second question through heuristics, audits, token analysis, and routing-risk signals.
+
+See **[Voyager vs Fathom](/docs/benchmarking/voyager-vs-fathom)** for the boundary.
+
+## Why this matters
+
+Without that separation, benchmarking tools tend to become muddy:
+
+- evaluators start acting like heuristic linters
+- heuristic tools start claiming benchmark truth
+- teams lose confidence in what each command is actually telling them
+
+Skill Harbor tries to keep the model clean:
+
+- **Voyager = empirical scenario evaluation**
+- **Fathom = predictive audit and fleet analysis**
+- **Skill Harbor overall = the governed system that makes both useful in practice**
+
+## How this aligns with SkillsBench
+
+SkillsBench is a strong research and evaluation lens.
+Skill Harbor takes the lessons of that lens and makes them **operational**:
+
+- benchmark-style scenarios can be run locally
+- packs can be checked into a repo
+- teams can use CI to keep evaluation repeatable
+- evaluation can be tied back to the governed fleet they actually use
+
+So the goal is not “be SkillsBench inside Skill Harbor.”
+The goal is:
+
+> make benchmark-style learning actionable inside a real engineering workflow.
+
+## Current direction
+
+The current Benchmarking direction in Skill Harbor is:
+
+1. **Voyager compare mode** for with-skills vs without-skills uplift
+2. **Harbor-native benchmark packs** for deterministic local/CI scenario evaluation
+3. **Fathom usefulness heuristics** informed later by empirical evaluation data
+4. **SkillsBench interop later**, as an adapter problem rather than a foundation dependency
+
+## Related pages
+
+- **[Voyager vs Fathom](/docs/benchmarking/voyager-vs-fathom)**
+- **[Voyager](/docs/foundations/voyager)**
+- **[Fathom](/docs/foundations/fathom)**
+- **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**

--- a/docs/benchmarking/voyager-vs-fathom.mdx
+++ b/docs/benchmarking/voyager-vs-fathom.mdx
@@ -1,0 +1,119 @@
+---
+title: "Voyager vs Fathom"
+description: "The product boundary between empirical scenario evaluation and predictive fleet analysis."
+icon: "split"
+---
+
+# 🧭 Voyager vs Fathom
+
+One of the easiest ways to confuse Skill Harbor's evaluation story is to blur **Voyager** and **Fathom** together.
+
+They are related, but they do different jobs.
+
+## Short version
+
+- **Voyager** measures what happens in a scenario.
+- **Fathom** analyzes what is likely to help or hurt before or across those scenarios.
+
+That distinction should stay intact even when Voyager adds deterministic benchmark packs.
+
+## Voyager: empirical scenario evaluation
+
+Voyager is the place for questions like:
+
+- Did the skill-enabled path outperform the no-skills path?
+- Did the agent invoke the expected tools?
+- Did the scenario pass or fail?
+- What trace did the run produce?
+- Can this evaluation be reproduced in CI?
+
+So Voyager owns:
+- scenario execution
+- branch comparison
+- traces
+- assertions
+- pass/fail outcomes
+- benchmark-pack results
+
+## Fathom: predictive and audit analysis
+
+Fathom is the place for questions like:
+
+- Is this fleet too large or too noisy?
+- Are skills colliding semantically?
+- Is the routing surface too vague?
+- How much context bloat is this adding?
+- Which skills look risky or promising before deeper evaluation?
+
+So Fathom owns:
+- heuristics
+- token/context analysis
+- contract validation
+- routing-risk signals
+- fleet-wide reports
+- predictive usefulness guidance
+
+## Why benchmark packs still belong in Voyager
+
+It may feel surprising that **offline deterministic packs** are still a Voyager feature.
+
+But the important boundary is **not**:
+- online = Voyager
+- offline = Fathom
+
+The real boundary is:
+- **scenario outcomes = Voyager**
+- **predictive audit = Fathom**
+
+A deterministic benchmark pack still asks a Voyager question:
+
+> what happened in this scenario, and how did the with-skills branch compare to the without-skills branch?
+
+That is still empirical evaluation, even when the evaluation is fixture-driven and reproducible in CI.
+
+## How they should work together
+
+The intended flow is:
+
+1. **Govern the fleet with Skill Harbor**
+2. **Inspect and predict with Fathom**
+3. **Measure scenario outcomes with Voyager**
+4. **Feed what you learn back into fleet refinement**
+
+In other words:
+
+- **Fathom** helps you decide what looks worth evaluating or trimming.
+- **Voyager** tells you what the scenario evidence actually says.
+
+## A practical rule
+
+If a command produces:
+- scenario traces
+- branch outcomes
+- assertion results
+- uplift/regression evidence
+
+it belongs in **Voyager**.
+
+If a command produces:
+- heuristics
+- token/collision reports
+- probabilistic routing confidence
+- fleet-level recommendations
+
+it belongs in **Fathom**.
+
+## Non-goal of Voyager benchmark packs
+
+Voyager benchmark packs should **not** become:
+- fleet health scores
+- heuristic usefulness scores
+- predictive deployment recommendations
+
+Those belong in Fathom.
+
+## Related pages
+
+- **[Benchmarking Overview](/docs/benchmarking/overview)**
+- **[Voyager](/docs/foundations/voyager)**
+- **[Fathom](/docs/foundations/fathom)**

--- a/docs/foundations/voyager.mdx
+++ b/docs/foundations/voyager.mdx
@@ -25,7 +25,7 @@ If Voyager discovers unmanaged local skills while preparing that fleet, it can a
 skill-harbor voyager -f harbor-voyager-test.yaml
 
 # Run an ad-hoc query simulation
-skill-harbor voyager --query "Check if the codebase is portable."
+skill-harbor voyager "Check if the codebase is portable."
 ```
 
 ---
@@ -53,6 +53,43 @@ mocks:
 - **`mocks`**: A mapping of tool names to their simulated return values. This prevents the agent from actually executing destructive commands during the test.
 
 ---
+
+
+## 🧪 Benchmark Packs
+
+Voyager now supports a **Harbor-native benchmark-pack** format for deterministic, fixture-driven scenario evaluation in local and CI environments. This complements the existing live single-scenario flow without replacing it.
+
+- **Legacy scenario files** remain the current single-test YAML shape (`query`, `expected_tools`, `mocks`, assertions).
+- **Benchmark-pack files** use a versioned Harbor-native root with `kind`, `version`, `pack`, and `scenarios`.
+- Pack execution is **offline and API-key-free** in v1: it evaluates scenario outcomes from fixtures rather than running the live provider loop.
+
+### Product boundary
+- **Voyager** owns empirical scenario evaluation: traces, branch outcomes, assertions, uplift/regression.
+- **Fathom** owns predictive and audit-style analysis: heuristics, token/context analysis, routing confidence, fleet recommendations.
+
+That means benchmark packs still belong in Voyager: they make **scenario evaluation reproducible**, but they do **not** compute Fathom-style usefulness heuristics.
+
+### Benchmark-pack example
+
+```yaml
+kind: harbor.voyager.benchmark-pack
+version: 1
+pack:
+  id: sample-benchmark-pack
+  name: Sample Voyager Benchmark Pack
+scenarios:
+  - id: tool-uplift
+    query: "Check if the codebase is portable and then generate a report on any hidden skills."
+    fixtures:
+      with_skills: ...
+      without_skills: ...
+    assertions:
+      with_skills: ...
+      without_skills: ...
+      delta: ...
+```
+
+Use a checked-in pack such as `harbor-voyager-benchmark-pack.yaml` to run deterministic benchmark-style evaluations in CI.
 
 ## 🛡️ Governance & CI/CD
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -34,6 +34,9 @@ Instead of manual skill installation or fragile global configurations, Skill Har
   <Card title="📏 Analysis + Verification" icon="chart-bar" href="/docs/foundations/fathom">
     `fathom` audits token load, contracts, and ghost skills. `voyager` simulates agent workflows. `check` validates berthed skill metadata.
   </Card>
+  <Card title="📊 Benchmarking" icon="chart-line" href="/docs/benchmarking/overview">
+    Learn how Skill Harbor approaches benchmarking: Voyager for empirical scenario evaluation, Fathom for predictive audit and fleet analysis, and Harbor as the operational layer connecting both.
+  </Card>
   <Card title="👻 Ghost Governance" icon="ghost" href="/docs/foundations/ghosts">
     Learn what Ghosts are, use the new `skill-harbor ghosts` workflow, and understand how ghost inspection relates to Fathom, Voyager, stowage, and managed sources.
   </Card>
@@ -137,6 +140,8 @@ Skill Harbor is built for the **Solo Captain** and the **Full Fleet Command**.
 
 ## ❓ Related FAQ
 
+- **[Benchmarking Overview](/docs/benchmarking/overview)**
+- **[Voyager vs Fathom](/docs/benchmarking/voyager-vs-fathom)**
 - **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**
 - **[Why Not Skills.sh?](/docs/faq/comparison)**
 - **[Why Not Agent Skill Harbor?](/docs/faq/agent-skill-harbor)**

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -4,6 +4,7 @@
     "quickstart",
     "skill-standards",
     "---",
+    "benchmarking",
     "foundations",
     "reference",
     "faq"

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -117,12 +117,24 @@ Primary ghost inspection workflow for unmanaged skills discovered in active bert
 ---
 
 ## `voyager`
-End-to-end integration testing suite for agent-skill loops.
+End-to-end integration testing suite for agent-skill loops and deterministic benchmark-pack evaluation.
+
+**Usage:**
+- `skill-harbor voyager [query]`
+- `skill-harbor voyager -f <path>`
 
 **Flags:**
-- `-f, --file <path>`: Provide a YAML test definition file containing mocks and assertions.
-- `--query <text>`: Run an ad-hoc query simulation.
-- `--model <name>`: Override the model used for the simulation.
+- `-f, --file <path>`: Provide either a legacy single-scenario YAML definition or a Harbor-native benchmark-pack file.
+- `-c, --compare`: Run the same legacy scenario with and without skills, then report the delta.
+- `--format <type>`: Output `pretty` or `json`.
+- `--save-trace [dir]`: Persist run artifacts. Pack runs write a top-level `summary.json` plus per-scenario artifacts.
+- `--model <name>`: Override the model used for live Voyager simulation.
+- `--baseUrl <url>`: Override the API base URL for live Voyager simulation.
+
+**Notes:**
+- Legacy single-scenario files and inline queries still use the live Voyager flow.
+- Benchmark-pack files are **fixture-driven and API-key-free** in v1, making them suitable for deterministic local/CI evaluation.
+- Direct SkillsBench ingestion is deferred; benchmark packs are Harbor-native.
 
 *For more details on integration testing, see the [Voyager Deep Dive](/docs/foundations/voyager).*
 

--- a/harbor-voyager-benchmark-pack.yaml
+++ b/harbor-voyager-benchmark-pack.yaml
@@ -1,0 +1,76 @@
+kind: harbor.voyager.benchmark-pack
+version: 1
+pack:
+  id: sample-benchmark-pack
+  name: Sample Voyager Benchmark Pack
+  description: Deterministic benchmark-pack example for local and CI evaluation.
+  tags:
+    - voyager
+    - benchmark
+    - ci
+scenarios:
+  - id: tool-uplift
+    name: Tool Uplift Example
+    query: "Check if the codebase is portable and then generate a report on any hidden skills."
+    tags:
+      - uplift
+      - regression
+    fixtures:
+      with_skills:
+        status: completed
+        final_answer: "Portable issues found: none. Hidden skills report generated."
+        iterations: 2
+        elapsed_ms: 120
+        available_tool_count: 2
+        trace_sequence:
+          - Scryer
+          - Fathom
+        trace:
+          - role: system
+            content: "system"
+          - role: user
+            content: "Check portability and hidden skills."
+          - role: assistant
+            content: ""
+          - role: tool
+            toolName: Scryer
+            content: "Portable issues found: none."
+          - role: tool
+            toolName: Fathom
+            content: "Hidden skills report: 2 ghost skills found."
+          - role: assistant
+            content: "Portable issues found: none. Hidden skills report generated."
+      without_skills:
+        status: failed
+        final_answer: "I could not complete both checks."
+        iterations: 1
+        elapsed_ms: 40
+        available_tool_count: 0
+        trace_sequence: []
+        trace:
+          - role: system
+            content: "system"
+          - role: user
+            content: "Check portability and hidden skills."
+          - role: assistant
+            content: "I could not complete both checks."
+    assertions:
+      with_skills:
+        expected_tools:
+          - Scryer
+          - Fathom
+        assert_final_contains:
+          - Hidden skills report
+        assert_status: completed
+      without_skills:
+        assert_status: failed
+      delta:
+        expect_assertion_improved: true
+        expect_status_changed: true
+        expect_status_summary: "failed -> completed"
+        expect_tool_count_delta:
+          eq: 2
+        expect_iteration_delta:
+          eq: 1
+        expect_elapsed_ms_delta:
+          eq: 80


### PR DESCRIPTION
## Summary

This PR adds the first Harbor-native benchmark-pack foundation for Voyager and documents the broader Benchmarking story in Skill Harbor.

### Commit groups
1. **Voyager benchmark-pack implementation**
   - versioned Harbor-native benchmark-pack contract
   - fixture-driven offline benchmark-pack lane
   - early pack/live discrimination before scope/config/API/berth discovery
   - additive-only preservation of existing single-scenario and compare behavior
   - delta assertions, negative validation coverage, sample benchmark pack, and changeset

2. **Benchmarking docs / product-boundary clarification**
   - dedicated `docs/benchmarking/` section
   - `Voyager vs Fathom` boundary page
   - updated Voyager and command docs
   - docs index/navigation updates

## Why

Skill Harbor needs a local-first, CI-friendly way to evaluate skill-enabled outcomes without coupling immediately to external benchmark task formats.

This PR keeps the product boundary explicit:
- **Voyager** = empirical scenario evaluation
- **Fathom** = predictive audit / fleet analysis

## Verification

- `cd apps/cli && npx vitest run src/commands/voyager.test.ts`
- `cd apps/cli && npx tsc --noEmit`
- `cd apps/cli && npm run build`
- `cd apps/cli && npx oxlint src/commands/voyager.ts src/commands/voyager.test.ts src/types/voyager.ts`
- no-key smoke run:
  - `cd apps/cli && unset HARBOR_PROFILER_API_KEY OPENAI_API_KEY && node dist/index.js voyager -f ../../harbor-voyager-benchmark-pack.yaml --format json --save-trace ../../.harbor/test-pack-run-post-deslop`

## Notes

- Includes a changeset for `skill-harbor`
- Does **not** implement direct SkillsBench ingestion
- Does **not** implement Fathom usefulness heuristics
