### PR TITLE
Make contracts native to check and default Fathom output

### DIFF
--- a/.changeset/bright-mice-judge.md
+++ b/.changeset/bright-mice-judge.md
@@ -1,5 +1,0 @@
----
-"skill-harbor": minor
----
-
-Add Harbor-native Voyager benchmark packs for deterministic local and CI evaluation.

--- a/.changeset/bright-mice-judge.md
+++ b/.changeset/bright-mice-judge.md
@@ -1,0 +1,5 @@
+---
+"skill-harbor": minor
+---
+
+Add Harbor-native Voyager benchmark packs for deterministic local and CI evaluation.

--- a/.changeset/harbor-benchmark-contract-tides.md
+++ b/.changeset/harbor-benchmark-contract-tides.md
@@ -1,0 +1,27 @@
+---
+"skill-harbor": minor
+---
+
+<!-- hero: Benchmark the Voyage, Chart the Contracts -->
+
+Captain's Briefing: Voyager can now sail deterministic benchmark packs for local and CI evaluation, while Harbor health checks can read and report native skill contracts. This pass also calms `up` output when stale manifest cargo is found.
+
+## ✨ New Cargo
+- `skill-harbor voyager --file` can now run Harbor-native benchmark pack YAML files, letting teams compare with-skills and without-skills outcomes from deterministic offline fixtures.
+- Voyager benchmark packs now support branch assertions, delta assertions, JSON summaries, and saved artifacts so CI jobs can prove whether a skill fleet actually improves an agent workflow.
+- New benchmarking and contract-validation docs explain how to write benchmark packs, when to use Voyager versus Fathom, and how to declare `Requires` / `Produces` contracts for chainable skills.
+
+## 🛡️ Hardened Hull
+- Added a native contract parser for skill frontmatter and markdown sections, including field validation and producer/consumer compatibility warnings.
+- Wired contract validation into `ProfilerService` so Fathom health reports can include contract status alongside token and confidence heuristics.
+- Upgraded `skill-harbor check --strict` to fail on invalid, missing, or warning-bearing contracts while normal checks still show contract status in the health output.
+
+## 🔧 Repaired Ships
+- `skill-harbor fathom` now shows contract health by default, and `--contracts` surfaces concrete contract errors and warnings instead of only noting missing chaining metadata.
+- `skill-harbor up` now rejects invalid remote source strings before invoking Skillfish and gives missing local sources a clear stale-manifest message.
+- `skill-harbor up` now keeps relative local source entries intact, avoids shell-joined Git hash checks, and stops raw progress output from replaying old spinner lines on every update.
+
+## 🛠️ Barnacle Scraping
+- Expanded regression coverage for `check`, `fathom`, `voyager`, `up`, manifest source resolution, local mooring errors, and deduped progress output.
+- Cleaned the workspace harbor manifest by removing the stale `test-skill` entry and keeping `quartermaster` docked from its relative project source.
+- Updated the project ignore rules to match the current overrides manifest location.

--- a/.changeset/olive-laws-count.md
+++ b/.changeset/olive-laws-count.md
@@ -1,5 +1,0 @@
----
-"skill-harbor": minor
----
-
-Make contract validation native to `check` and include contract health in default `fathom` output/reporting.

--- a/.changeset/olive-laws-count.md
+++ b/.changeset/olive-laws-count.md
@@ -1,0 +1,5 @@
+---
+"skill-harbor": minor
+---
+
+Make contract validation native to `check` and include contract health in default `fathom` output/reporting.

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ tsconfig.tsbuildinfo
 .env*
 .npmrc
 *.tgz
-harbor-manifest.local.json
+.harbor/harbor-manifest.overrides.json
 harbor-compass.yaml
 *voyage-test.yaml
 

--- a/.harbor/harbor-manifest.json
+++ b/.harbor/harbor-manifest.json
@@ -2,28 +2,35 @@
   "version": "1.0",
   "dependencies": {
     "scryer": "https://github.com/johntimothybailey/sia/skills/scryer",
-    "quartermaster": "./skills/quartermaster"
+    "quartermaster": "/Users/johnbailey/Development/Yamanu/skill-harbor/skills/quartermaster"
   },
   "skills": {
     "scryer": {
       "name": "scryer",
       "source": "https://github.com/johntimothybailey/sia/skills/scryer",
       "localPath": "/Users/johnbailey/Development/Yamanu/skill-harbor/.harbor/skills/scryer",
-      "lastSyncHash": "https://github.com/johntimothybailey/sia/skills/scryer:c0ec1c92c4ed71a094bcc39adcc0b414a317102c",
+      "lastSyncHash": "https://github.com/johntimothybailey/sia/skills/scryer:76860f416b8a60a0c6facc483310c2ca30362d66",
       "lastSyncTargets": [
         "claude",
-        "cursor"
+        "cursor",
+        "copilot",
+        "codex",
+        "rulesync"
       ]
-    },
-    "test-skill": {
-      "name": "test-skill",
-      "source": "local",
-      "localPath": ".harbor/test-skill"
     },
     "quartermaster": {
       "name": "quartermaster",
-      "source": "./skills/quartermaster",
-      "localPath": ""
+      "source": "/Users/johnbailey/Development/Yamanu/skill-harbor/skills/quartermaster",
+      "sourceType": "single",
+      "localPath": "/Users/johnbailey/Development/Yamanu/skill-harbor/.harbor/skills/quartermaster",
+      "lastSyncHash": "ae26087dd079d5ab3ed0f0904da02ec3",
+      "lastSyncTargets": [
+        "claude",
+        "cursor",
+        "copilot",
+        "codex",
+        "rulesync"
+      ]
     }
   }
 }

--- a/apps/cli/src/commands/check.test.ts
+++ b/apps/cli/src/commands/check.test.ts
@@ -5,6 +5,7 @@ import { Orchestrator } from '../orchestrator';
 import { getAgentBerths, getManifestManager, exists } from '../utils';
 import { printHeader, printInfo } from '../ui';
 import os from 'node:os';
+import { ProfilerService } from '../services/profiler';
 
 vi.mock('../command-scope');
 vi.mock('../orchestrator');
@@ -12,13 +13,18 @@ vi.mock('../utils');
 vi.mock('../ui');
 vi.mock('spinnies');
 vi.mock('node:os');
+vi.mock('../services/profiler');
 
 describe('checkAction', () => {
     let mockOrchestrator: any;
     let mockManifestManager: any;
+    let mockProfiler: any;
 
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('exit');
+        }) as any);
         mockOrchestrator = {
             getMetadata: vi.fn().mockResolvedValue({ name: 'skill1', description: 'desc', triggers: [] }),
         };
@@ -37,8 +43,20 @@ describe('checkAction', () => {
             getSkillsCacheDir: vi.fn().mockReturnValue('/harbor'),
             getHarborDir: vi.fn().mockReturnValue('/harbor'),
         };
+        mockProfiler = {
+            getContractValidation: vi.fn().mockResolvedValue({
+                missingStandard: false,
+                requires: { input_text: 'string' },
+                produces: { summary: 'json' },
+                isValid: true,
+                status: 'valid',
+                errors: [],
+                warnings: []
+            })
+        };
         (resolveCommandScope as any).mockResolvedValue({ useGlobalScope: false, shouldStop: false });
         (Orchestrator as any).mockImplementation(function() { return mockOrchestrator; });
+        (ProfilerService as any).mockImplementation(function() { return mockProfiler; });
         (getManifestManager as any).mockReturnValue(mockManifestManager);
         (getAgentBerths as any).mockResolvedValue([
             { path: '/app/.claude/skills', label: 'Claude', key: 'claude' },
@@ -58,6 +76,7 @@ describe('checkAction', () => {
 
         expect(printHeader).toHaveBeenCalledWith('Lighthouse Health Check');
         expect(mockOrchestrator.getMetadata).toHaveBeenCalled();
+        expect(mockProfiler.getContractValidation).toHaveBeenCalled();
     });
 
     it('should handle empty harbor', async () => {
@@ -85,5 +104,75 @@ describe('checkAction', () => {
 
         expect(mockManifestManager.readMerged).not.toHaveBeenCalled();
         expect(mockOrchestrator.getMetadata).not.toHaveBeenCalled();
+    });
+
+    it('fails when contracts are invalid', async () => {
+        const options = {};
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        mockProfiler.getContractValidation.mockResolvedValue({
+            missingStandard: false,
+            requires: {},
+            produces: {},
+            isValid: false,
+            status: 'invalid',
+            errors: ["contracts.produces.summary has unknown type 'structured-json-ish'"],
+            warnings: []
+        });
+
+        await expect(checkAction(options, mockCommand)).rejects.toThrow('exit');
+    });
+
+    it('warns but does not fail on missing contracts by default', async () => {
+        const options = {};
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        mockProfiler.getContractValidation.mockResolvedValue({
+            missingStandard: true,
+            requires: {},
+            produces: {},
+            isValid: true,
+            status: 'missing',
+            errors: [],
+            warnings: []
+        });
+
+        await checkAction(options, mockCommand);
+    });
+
+    it('fails missing contracts in strict mode', async () => {
+        const options = { strict: true };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        mockProfiler.getContractValidation.mockResolvedValue({
+            missingStandard: true,
+            requires: {},
+            produces: {},
+            isValid: true,
+            status: 'missing',
+            errors: [],
+            warnings: []
+        });
+
+        await expect(checkAction(options, mockCommand)).rejects.toThrow('exit');
+    });
+
+    it('warns on underspecified contracts by default but fails them in strict mode', async () => {
+        const warningContracts = {
+            missingStandard: false,
+            requires: { input_text: 'any' },
+            produces: {},
+            isValid: true,
+            status: 'valid',
+            errors: [],
+            warnings: ['contracts.requires.input_text is underspecified.']
+        };
+
+        const defaultOptions = {};
+        const defaultCommand = { opts: vi.fn().mockReturnValue(defaultOptions) };
+        mockProfiler.getContractValidation.mockResolvedValueOnce(warningContracts);
+        await checkAction(defaultOptions, defaultCommand);
+
+        const strictOptions = { strict: true };
+        const strictCommand = { opts: vi.fn().mockReturnValue(strictOptions) };
+        mockProfiler.getContractValidation.mockResolvedValueOnce(warningContracts);
+        await expect(checkAction(strictOptions, strictCommand)).rejects.toThrow('exit');
     });
 });

--- a/apps/cli/src/commands/check.ts
+++ b/apps/cli/src/commands/check.ts
@@ -6,12 +6,15 @@ import { resolveCommandScope } from "../command-scope";
 import { Orchestrator } from "../orchestrator";
 import { getManifestManager, exists, getAgentBerths } from "../utils";
 import { printHeader, printError, printInfo } from "../ui";
+import { ProfilerService } from "../services/profiler";
 
 export async function checkAction(options: any, command: any) {
     const opts = command.opts();
     const manifestManager = getManifestManager(opts);
     const baseDir = opts.global ? os.homedir() : process.cwd();
     const spinnies = new Spinnies();
+    const profiler = new ProfilerService();
+    let hasFailures = false;
 
     try {
         printHeader("Lighthouse Health Check");
@@ -59,6 +62,17 @@ export async function checkAction(options: any, command: any) {
                 ? kleur.green(`📡 Discoverable (${meta!.description.substring(0, 40)}...)`)
                 : kleur.red("📡 Blind (Missing or invalid SKILL.md)");
 
+            const contracts = (await profiler.getContractValidation(cachedPath)) ?? {
+                missingStandard: true,
+                requires: {},
+                produces: {},
+                isValid: true,
+                status: "missing" as const,
+                errors: [],
+                warnings: []
+            };
+            const contractStatus = formatContractCheckStatus(contracts);
+
             // 2. Berth Verification
             const mooredIn: string[] = [];
             const missingFrom: string[] = [];
@@ -84,15 +98,44 @@ export async function checkAction(options: any, command: any) {
                 berthStatus = kleur.gray("No active agent berths detected.");
             }
 
-            const statusText = `[${kleur.bold(skill.name)}]${layerLabel}\n    ${metaStatus}\n    ${berthStatus}`;
+            const statusText = `[${kleur.bold(skill.name)}]${layerLabel}\n    ${metaStatus}\n    ${contractStatus}\n    ${berthStatus}`;
+            const contractInvalid = contracts.status === "invalid";
+            const contractMissingStrict = opts.strict && contracts.status === "missing";
+            const contractWarningStrict = opts.strict && contracts.warnings.length > 0;
+            const skillFailed = !isDiscoverable || missingFrom.length > 0 || contractInvalid || contractMissingStrict || contractWarningStrict;
             
-            if (isDiscoverable && missingFrom.length === 0) {
+            if (!skillFailed) {
                 spinnies.succeed(`check-${skill.name}`, { text: statusText });
             } else {
+                hasFailures = true;
                 spinnies.fail(`check-${skill.name}`, { text: statusText });
             }
         }
+
+        if (hasFailures) {
+            process.exit(1);
+        }
     } catch (error: any) {
+        if (error?.message === "exit") {
+            throw error;
+        }
         printError(`Check failed: ${error.message}`);
     }
+}
+
+function formatContractCheckStatus(contracts: NonNullable<Awaited<ReturnType<ProfilerService["getContractValidation"]>>>) {
+    if (contracts.status === "valid") {
+        const requires = Object.keys(contracts.requires);
+        const produces = Object.keys(contracts.produces);
+        if (contracts.warnings.length > 0) {
+            return kleur.yellow(`🤝 Contracts: warning (${contracts.warnings.join("; ")})`);
+        }
+        return kleur.green(`🤝 Contracts: valid${requires.length || produces.length ? ` (Requires: [${requires.join(", ") || "none"}] | Produces: [${produces.join(", ") || "none"}])` : ""}`);
+    }
+
+    if (contracts.status === "invalid") {
+        return kleur.red(`🤝 Contracts: invalid (${contracts.errors.join("; ")})`);
+    }
+
+    return kleur.yellow("🤝 Contracts: missing");
 }

--- a/apps/cli/src/commands/fathom.test.ts
+++ b/apps/cli/src/commands/fathom.test.ts
@@ -332,6 +332,133 @@ describe("fathomAction", () => {
         logSpy.mockRestore();
     });
 
+    it("shows contract health in default per-skill output without --contracts", async () => {
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        const options = {};
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                skill1: { name: "skill1", source: "source1", layer: "shared" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "skill1", layer: "shared" }]);
+        (exists as any).mockImplementation(async (candidatePath: string) => candidatePath === "/harbor/skill1");
+        mockProfiler.calculateDisplacement.mockResolvedValue({
+            icon: "🛶",
+            shipClass: "Dinghy",
+            tokens: 100,
+            cost: { gpt4o: 0.001, gpt4oMini: 0.0001 }
+        });
+        mockProfiler.calculateHeuristicConfidence.mockResolvedValue({
+            score: 7,
+            condition: "Calm Seas",
+            skillType: "Agent Skill",
+            validation: { isProperlyFormatted: true, errors: [] },
+            heuristics: {
+                semanticVagueness: 0,
+                negativeConstraints: 0,
+                tagDensity: 0,
+                triggerClarity: 1
+            },
+            contracts: {
+                missingStandard: false,
+                requires: { input_text: "string" },
+                produces: { summary: "json" },
+                isValid: true,
+                status: "valid",
+                errors: [],
+                warnings: []
+            }
+        });
+
+        await fathomAction(options, mockCommand);
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Contracts:"));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("healthy"));
+        logSpy.mockRestore();
+    });
+
+    it("includes contract coverage and mismatches in report mode by default", async () => {
+        const options = { report: true, format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                skill1: { name: "skill1", source: "source1", layer: "shared" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "skill1", layer: "shared" }]);
+        mockProfiler.findSkills.mockResolvedValue(["/harbor/skill1"]);
+        mockProfiler.generateHealthReport.mockResolvedValue({
+            totalSkills: 1,
+            totalTokens: 100,
+            totalCost: { gpt4o: 0.001, gpt4oMini: 0.0001 },
+            averageHeuristicConfidence: 7,
+            composition: { agent: 1, tools: 0 },
+            shipDistribution: { Dinghy: 1, Schooner: 0, Brigantine: 0, Frigate: 0, Galleon: 0 },
+            contextBloat: [],
+            status: { isHealthy: true, violations: [] },
+            contractCoverage: 100,
+            contractWarnings: [],
+            contractMismatches: []
+        });
+        (exists as any).mockImplementation(async (candidatePath: string) => candidatePath === "/codex/skill1");
+        (getAgentBerths as any).mockResolvedValue([{ path: "/codex", label: "Codex", key: "codex" }]);
+        (getStowageBerths as any).mockResolvedValue([]);
+
+        await fathomAction(options, mockCommand);
+
+        expect(mockProfiler.generateHealthReport).toHaveBeenCalledWith(
+            ["/harbor/skill1"],
+            expect.anything(),
+            undefined,
+            expect.anything(),
+            false
+        );
+        expect(printHarborHealthReport).toHaveBeenCalledWith(expect.objectContaining({
+            contractCoverage: 100
+        }), "json");
+    });
+
+    it("includes parser-level contract warnings in report mode and strict mode", async () => {
+        const options = { report: true, format: "json", contracts: true };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                skill1: { name: "skill1", source: "source1", layer: "shared" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "skill1", layer: "shared" }]);
+        mockProfiler.findSkills.mockResolvedValue(["/harbor/skill1"]);
+        mockProfiler.generateHealthReport.mockResolvedValue({
+            totalSkills: 1,
+            totalTokens: 100,
+            totalCost: { gpt4o: 0.001, gpt4oMini: 0.0001 },
+            averageHeuristicConfidence: 7,
+            composition: { agent: 1, tools: 0 },
+            shipDistribution: { Dinghy: 1, Schooner: 0, Brigantine: 0, Frigate: 0, Galleon: 0 },
+            contextBloat: [],
+            status: { isHealthy: false, violations: ["[skill1] contracts.requires.input_text is underspecified."] },
+            contractCoverage: 100,
+            contractWarnings: ["[skill1] contracts.requires.input_text is underspecified."],
+            contractMismatches: []
+        });
+        (exists as any).mockImplementation(async (candidatePath: string) => candidatePath === "/codex/skill1");
+        (getAgentBerths as any).mockResolvedValue([{ path: "/codex", label: "Codex", key: "codex" }]);
+        (getStowageBerths as any).mockResolvedValue([]);
+        vi.spyOn(process, "exit").mockImplementation((() => {
+            throw new Error("exit");
+        }) as any);
+
+        await expect(fathomAction(options, mockCommand)).rejects.toThrow("exit");
+
+        expect(printHarborHealthReport).toHaveBeenCalledWith(expect.objectContaining({
+            contractWarnings: ["[skill1] contracts.requires.input_text is underspecified."]
+        }), "json");
+    });
+
     it("adds structured vessel placement detail to report output", async () => {
         const options = { report: true, format: "json" };
         const mockCommand = { opts: vi.fn().mockReturnValue(options) };

--- a/apps/cli/src/commands/fathom.ts
+++ b/apps/cli/src/commands/fathom.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import kleur from "kleur";
 import Spinnies from "spinnies";
@@ -23,7 +24,6 @@ import {
 import type { GhostScanContext } from "../services/ghosts";
 import type { BerthDetail } from "../utils";
 import { printHeader, printError, printInfo, printHarborHealthReport, printSuccess } from "../ui";
-import os from "node:os";
 
 type VesselPlacement = {
     name: string;
@@ -44,12 +44,14 @@ export async function fathomAction(options: any, command: any) {
     
     const showDetails = opts.details ?? false;
     const showReport = opts.report ?? false;
+    const format = opts.format ?? "pretty";
+    const isPrettyFormat = format === "pretty";
     const query = opts.query;
     const modelOverride = opts.model;
     const baseUrlOverride = opts.baseUrl;
 
     try {
-        if (!opts.format || opts.format === "pretty") {
+        if (isPrettyFormat) {
             printHeader("Fathom: Skill Profiler");
         }
 
@@ -107,18 +109,17 @@ export async function fathomAction(options: any, command: any) {
         }
 
         // 3. Override Warnings
-        if (!useGlobalScope && manifest.overrides && manifest.overrides.length > 0 && (!opts.format || opts.format === "pretty")) {
+        if (!useGlobalScope && manifest.overrides && manifest.overrides.length > 0 && isPrettyFormat) {
             console.log(kleur.yellow(`\n⚠️  Overrides Active: The following skills are being overridden by personal definitions in harbor-manifest.overrides.json:`));
             manifest.overrides.forEach((name: string) => console.log(kleur.yellow(`   - ${name}`)));
             console.log("");
         }
-        if (opts.ghosts && friendlyGhostCount > 0 && (!opts.format || opts.format === "pretty")) {
+        if (opts.ghosts && friendlyGhostCount > 0 && isPrettyFormat) {
             console.log(kleur.cyan(`\n💡 ${friendlyGhostCount} friendly ghost${friendlyGhostCount === 1 ? "" : "s"} hidden from the main ghost list. Use 'skill-harbor ghosts --friendly' for details.`));
         }
 
         // --- Harbor Health Report ---
         if (showReport) {
-            const format = opts.format ?? 'pretty';
             const cacheDirs = [
                 ...new Set(
                     skills
@@ -127,7 +128,7 @@ export async function fathomAction(options: any, command: any) {
                 )
             ];
             
-            if (format === 'pretty') {
+            if (isPrettyFormat) {
                 spinnies.add("harbor-scan", { text: `Scanning Harbor caches: ${kleur.cyan(cacheDirs.join(", "))}` });
             }
             
@@ -144,7 +145,7 @@ export async function fathomAction(options: any, command: any) {
             }
 
             if (skillPaths.length === 0) {
-                if (format === 'pretty') {
+                if (isPrettyFormat) {
                     spinnies.fail("harbor-scan", { text: "No vessels found to fathom. Check manifest or berths." });
                 } else {
                     console.error(JSON.stringify({ error: "No vessels found" }));
@@ -152,7 +153,9 @@ export async function fathomAction(options: any, command: any) {
                 return;
             }
 
-            if (format === 'pretty') spinnies.update("harbor-scan", { text: `Analyzing ${skillPaths.length} skills for context bloat...` });
+            if (isPrettyFormat) {
+                spinnies.update("harbor-scan", { text: `Analyzing ${skillPaths.length} skills for context bloat...` });
+            }
             
             const thresholds = {
                 maxTokens: opts.maxTokens ? parseInt(opts.maxTokens) : undefined,
@@ -160,7 +163,7 @@ export async function fathomAction(options: any, command: any) {
                 minScore: opts.minScore ? parseFloat(opts.minScore) : undefined
             };
 
-            const report = await profiler.generateHealthReport(skillPaths, thresholds, query, config.sonar, opts.contracts);
+            const report = await profiler.generateHealthReport(skillPaths, thresholds, query, config.sonar, Boolean(opts.contracts));
             
             // Calculate Fleet Status for the report
             const fleetStatus = { berthed: 0, stowed: 0, dryDock: 0 };
@@ -183,7 +186,7 @@ export async function fathomAction(options: any, command: any) {
             report.fleetStatus = fleetStatus;
             report.vesselPlacements = vesselPlacements;
 
-            if (format === 'pretty') {
+            if (isPrettyFormat) {
                 spinnies.succeed("harbor-scan", { text: `Fleet audit complete. ${skillPaths.length} vessels scanned.` });
             }
             
@@ -245,7 +248,7 @@ export async function fathomAction(options: any, command: any) {
                     spinnies.update(`fathom-${skill.name}`, { text: `Conducting Sonar Audit for ${kleur.bold(skill.name)}...` });
                     try {
                         sonarResult = await profiler.conductSonarAudit(skill.name, cachedPath, query, config.sonar);
-                    } catch (err: any) {
+                    } catch {
                         // Sonar failed but we continue with heuristic
                     }
                 }
@@ -267,7 +270,12 @@ export async function fathomAction(options: any, command: any) {
 
                 let sonarText = kleur.gray("[Offline - Provide --query]");
                 if (sonarResult) {
-                    const sonarColor = sonarResult.score > 80 ? kleur.green : sonarResult.score > 50 ? kleur.yellow : kleur.red;
+                    let sonarColor = kleur.red;
+                    if (sonarResult.score > 80) {
+                        sonarColor = kleur.green;
+                    } else if (sonarResult.score > 50) {
+                        sonarColor = kleur.yellow;
+                    }
                     const barLength = 10;
                     const filledLength = Math.round((sonarResult.score / 100) * barLength);
                     const bar = sonarColor("█".repeat(filledLength)) + kleur.gray("░".repeat(barLength - filledLength));
@@ -293,18 +301,27 @@ export async function fathomAction(options: any, command: any) {
                 console.log(`    ${kleur.cyan("Confidence (Heuristic):")} ${heuristicText} ${heuristicSubtext}`);
                 console.log(`    ${kleur.cyan("Confidence (Sonar):")}     ${sonarText}`);
 
-                if (opts.contracts) {
-                    if (heuristic.contracts?.missingStandard) {
-                        console.log(`    ${kleur.yellow("Contracts:")}              ⚠️  Not explicitly configured for chaining. (See: https://docs.skill-harbor.app/concepts/skill-standards#-semantic-contracts-io)`);
-                    } else if (heuristic.contracts) {
-                        const reqStr = Object.keys(heuristic.contracts.requires).length > 0 
-                            ? Object.keys(heuristic.contracts.requires).join(", ") 
-                            : "none";
-                        const prodStr = Object.keys(heuristic.contracts.produces).length > 0 
-                            ? Object.keys(heuristic.contracts.produces).join(", ") 
-                            : "none";
-                        console.log(`    ${kleur.cyan("Contracts:")}              Requires: [${reqStr}] | Produces: [${prodStr}]`);
-                    }
+                const contracts = heuristic.contracts;
+                if (contracts?.status === "valid" && contracts.warnings.length > 0) {
+                    console.log(`    ${kleur.yellow("Contracts:")}              warning (${contracts.warnings.join("; ")})`);
+                } else if (contracts?.status === "valid") {
+                    const reqStr = Object.keys(contracts.requires).length > 0
+                        ? Object.keys(contracts.requires).join(", ")
+                        : "none";
+                    const prodStr = Object.keys(contracts.produces).length > 0
+                        ? Object.keys(contracts.produces).join(", ")
+                        : "none";
+                    console.log(`    ${kleur.cyan("Contracts:")}              ${kleur.green("healthy")} (Requires: [${reqStr}] | Produces: [${prodStr}])`);
+                } else if (contracts?.status === "invalid") {
+                    console.log(`    ${kleur.red("Contracts:")}              invalid (${contracts.errors.join("; ")})`);
+                } else {
+                    console.log(`    ${kleur.yellow("Contracts:")}              warning (missing explicit chaining contract)`);
+                }
+
+                if (opts.contracts && contracts?.status === "invalid" && contracts.errors.length > 0) {
+                    console.log(`    ${kleur.red("Contract Errors:")}        ${contracts.errors.join("; ")}`);
+                } else if (opts.contracts && contracts?.warnings.length) {
+                    console.log(`    ${kleur.yellow("Contract Warnings:")}     ${contracts.warnings.join("; ")}`);
                 }
 
                 if (showDetails) {
@@ -346,7 +363,7 @@ export async function fathomAction(options: any, command: any) {
                     }
 
                     console.log(kleur.gray("    ─────────────────────────────────────"));
-                    const ratingLabel = heuristic.score >= 9 ? "Excellent" : heuristic.score >= 7 ? "Good" : heuristic.score >= 5 ? "Fair" : heuristic.score >= 3 ? "Poor" : "Critical";
+                    const ratingLabel = getRatingLabel(heuristic.score);
                     console.log(`    ${heuristicEmoji} ${kleur.bold("Rating:")} ${heuristicColor(ratingLabel)} — ${getRatingAdvice(heuristic.score)}`);
                 }
 
@@ -364,7 +381,7 @@ export async function fathomAction(options: any, command: any) {
         }
 
         // 5. Interactive Ghost Docking
-        if (opts.ghosts && ghostSkillPaths.length > 0 && (!opts.format || opts.format === "pretty")) {
+        if (opts.ghosts && ghostSkillPaths.length > 0 && isPrettyFormat) {
             const targetLayer = useGlobalScope ? "global" : "local";
             const scopeLabel = useGlobalScope ? "global" : "local";
 
@@ -387,13 +404,29 @@ export async function fathomAction(options: any, command: any) {
             }
         }
     } catch (error: any) {
+        if (error?.message === "exit") {
+            throw error;
+        }
         printError(`Fathom failed: ${error.message}`);
     }
 }
 
 function printDetailRow(label: string, value: string, explanation: string): void {
-    const valColor = value.startsWith("+") ? kleur.green(value) : value === "0" ? kleur.gray(value) : kleur.red(value);
+    let valColor = kleur.red(value);
+    if (value.startsWith("+")) {
+        valColor = kleur.green(value);
+    } else if (value === "0") {
+        valColor = kleur.gray(value);
+    }
     console.log(`    ${kleur.bold(label.padEnd(12))} ${valColor.padEnd(5)}  ${kleur.gray(explanation)}`);
+}
+
+function getRatingLabel(score: number): string {
+    if (score >= 9) return "Excellent";
+    if (score >= 7) return "Good";
+    if (score >= 5) return "Fair";
+    if (score >= 3) return "Poor";
+    return "Critical";
 }
 
 function getRatingAdvice(score: number): string {

--- a/apps/cli/src/commands/up.test.ts
+++ b/apps/cli/src/commands/up.test.ts
@@ -31,8 +31,7 @@ vi.mock('spinnies', () => ({
 }));
 vi.mock('fast-glob');
 vi.mock('node:child_process', () => ({
-    exec: vi.fn(),
-    execAsync: vi.fn().mockResolvedValue({ stdout: '' })
+    execFile: vi.fn((_command: string, _args: string[], _options: any, callback: any) => callback(null, { stdout: '' }))
 }));
 
 import { lstatSync } from 'node:fs';
@@ -545,6 +544,37 @@ describe('upAction', () => {
         await upAction(options, mockCommand);
 
         expect(mockOrchestrator.moor).toHaveBeenCalledWith('./local-skill');
+    });
+
+    it('should sync with resolved relative paths without persisting absolute sources', async () => {
+        const options = {};
+        const mockCommand = {
+            opts: vi.fn().mockReturnValue(options),
+        };
+        process.cwd = vi.fn().mockReturnValue('/app');
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                'quartermaster': {
+                    name: 'quartermaster',
+                    source: './skills/quartermaster',
+                    resolvedSource: '/app/skills/quartermaster',
+                    layer: 'shared'
+                }
+            }
+        });
+        (glob as any).mockResolvedValue(['/app/skills/quartermaster/SKILL.md']);
+
+        await upAction(options, mockCommand);
+
+        expect(mockOrchestrator.moor).toHaveBeenCalledWith('/app/skills/quartermaster');
+        expect(mockManifestManager.addSkill).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: 'quartermaster',
+                source: './skills/quartermaster',
+                localPath: '/harbor/quartermaster'
+            }),
+            'shared'
+        );
     });
 
     it('should report failures and exit 1', async () => {

--- a/apps/cli/src/commands/up.ts
+++ b/apps/cli/src/commands/up.ts
@@ -2,20 +2,20 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { lstatSync } from "node:fs";
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import crypto from "node:crypto";
 import glob from "fast-glob";
 import kleur from "kleur";
-import Spinnies from "spinnies";
 import { GeneratedSkillEntry, ManifestLayer, ManifestManager, SkillEntry } from "../manifest";
 import { Orchestrator } from "../orchestrator";
 import { getManifestManager, getAgentBerths, exists, getManagedAgentTargets, getSupportedTargetKeys } from "../utils";
 import { printHeader, printSuccess, printError, printInfo, promptEmptyProjectHarborAction, promptSelectTargets } from "../ui";
 import { migrateAction } from "./migrate";
 import { ProfilerService } from "../services/profiler";
+import { createSyncProgressReporter, type ProgressReporter } from "../progress";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Automates adding local-only harbor files and cache directories to .gitignore.
@@ -104,7 +104,7 @@ async function getSourceHash(source: string): Promise<string> {
 
             if (repo) {
                 const repoUrl = `https://github.com/${repo}.git`;
-                const { stdout } = await execAsync(`git ls-remote ${repoUrl} ${ref}`, { timeout: 5000 });
+                const { stdout } = await execFileAsync("git", ["ls-remote", repoUrl, ref], { timeout: 5000 });
                 const remoteHash = stdout.split(/\s+/)[0];
                 if (remoteHash) return `${source}:${remoteHash}`;
             }
@@ -159,6 +159,10 @@ type SyncLeafSkill = {
     previous?: GeneratedSkillEntry | SkillEntry;
 };
 
+function getSyncSource(skill: SkillEntry | GeneratedSkillEntry): string {
+    return (skill as SkillEntry).resolvedSource ?? skill.source;
+}
+
 function normalizeLocalSourcePath(source: string): string {
     return path.resolve(process.cwd(), source.replace("file://", ""));
 }
@@ -168,7 +172,7 @@ async function syncLeafSkill(params: {
     skillLayer: string;
     activeTargetConfigs: Array<{ path: string; label: string; key: string }>;
     manifestManager: any;
-    spinnies: Spinnies;
+    spinnies: ProgressReporter;
     options: any;
 }): Promise<GeneratedSkillEntry> {
     const { leaf, skillLayer, activeTargetConfigs, manifestManager, spinnies, options } = params;
@@ -268,7 +272,7 @@ export async function upAction(options: any, command: any) {
     const manifestManager = getManifestManager(opts);
     // Concurrent sync is easier to read as deterministic line updates than as
     // animated multi-spinner rendering, especially in mixed success/failure runs.
-    const spinnies = new Spinnies({ disableSpins: true });
+    const spinnies = createSyncProgressReporter();
 
     try {
         printHeader("Workspace Synchronization Initiated");
@@ -406,13 +410,13 @@ export async function upAction(options: any, command: any) {
         const syncPromises = skills.map(async (skill) => {
             try {
                 const skillLayer = skill.layer || (useGlobalScope ? "global" : "shared");
-                const currentSourceHash = await getSourceHash(skill.source);
+                const currentSourceHash = await getSourceHash(getSyncSource(skill));
                 const activeTargets = activeTargetConfigs.map(target => target.key);
                 const targetsChanged = JSON.stringify([...activeTargets].sort()) !== JSON.stringify([...(skill.lastSyncTargets || [])].sort());
                 const sourceChanged = currentSourceHash !== skill.lastSyncHash;
 
                 if (skill.sourceType === "folder") {
-                    const absoluteRoot = normalizeLocalSourcePath(skill.source);
+                    const absoluteRoot = normalizeLocalSourcePath(getSyncSource(skill));
                     const discovered = (await profiler.findSkills(absoluteRoot))
                         .filter(foundPath => path.resolve(foundPath) !== absoluteRoot)
                         .sort((left, right) => path.basename(left).localeCompare(path.basename(right)));
@@ -504,7 +508,7 @@ export async function upAction(options: any, command: any) {
                 const syncedLeaf = await syncLeafSkill({
                     leaf: {
                         name: skill.name,
-                        source: skill.source,
+                        source: getSyncSource(skill),
                         previous: skill
                     },
                     skillLayer,

--- a/apps/cli/src/commands/voyager.test.ts
+++ b/apps/cli/src/commands/voyager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import matter from "gray-matter";
+import yaml from "js-yaml";
 import { voyagerAction } from "./voyager";
 import { resolveCommandScope } from "../command-scope";
 import { ask, getAgentBerths, getManifestManager } from "../utils";
@@ -84,6 +85,7 @@ describe("voyagerAction", () => {
         (fs.mkdir as any).mockResolvedValue(undefined);
         (fs.writeFile as any).mockResolvedValue(undefined);
         (matter as any).mockReturnValue({ data: {} });
+        vi.mocked(yaml.load as any).mockReset();
         consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
         vi.spyOn(process, "exit").mockImplementation((() => {
             throw new Error("exit");
@@ -211,7 +213,241 @@ describe("voyagerAction", () => {
         expect(withoutSkillsBody.tools).toBeUndefined();
         expect(withoutSkillsBody.tool_choice).toBeUndefined();
     });
+
+    it("loads a valid benchmark pack, skips live setup, and emits pack json", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        vi.mocked(yaml.load as any).mockReturnValue(buildValidPack());
+
+        await voyagerAction(undefined, options, mockCommand);
+
+        expect(resolveCommandScope).not.toHaveBeenCalled();
+        expect(mockConfigManager.loadConfig).not.toHaveBeenCalled();
+        expect(getAgentBerths).not.toHaveBeenCalled();
+        expect(discoverGhosts).not.toHaveBeenCalled();
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls.at(-1)[0]);
+        expect(jsonOutput.kind).toBe("harbor.voyager.benchmark-pack.result");
+        expect(jsonOutput.pass).toBe(true);
+        expect(jsonOutput.totals.scenarios_total).toBe(1);
+    });
+
+    it("saves benchmark pack artifacts with the expected layout", async () => {
+        const options = { file: "pack.yaml", format: "json", saveTrace: true };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        vi.mocked(yaml.load as any).mockReturnValue(buildValidPack());
+
+        await voyagerAction(undefined, options, mockCommand);
+
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("summary.json"), expect.any(String), "utf-8");
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("scenarios/basic-pack-scenario/with-skills.json"), expect.any(String), "utf-8");
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("scenarios/basic-pack-scenario/without-skills.json"), expect.any(String), "utf-8");
+        expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("scenarios/basic-pack-scenario/summary.json"), expect.any(String), "utf-8");
+    });
+
+    it("fails a pack when a scenario fails", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        pack.scenarios[0].assertions.with_skills.assert_status = "failed";
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+    });
+
+    it.each([
+        ["missing kind", (() => { const pack = buildValidPack(); delete pack.kind; return pack; })()],
+        ["wrong kind", (() => { const pack = buildValidPack(); pack.kind = "wrong.kind"; return pack; })()],
+        ["unsupported version", (() => { const pack = buildValidPack(); pack.version = 2; return pack; })()],
+        ["missing pack id", (() => { const pack = buildValidPack(); delete pack.pack.id; return pack; })()],
+        ["invalid scenario id", (() => { const pack = buildValidPack(); pack.scenarios[0].id = "Bad Id"; return pack; })()],
+        ["duplicate scenario ids", (() => { const pack = buildValidPack(); pack.scenarios.push({ ...pack.scenarios[0] }); return pack; })()],
+        ["missing with_skills fixture", (() => { const pack = buildValidPack(); delete pack.scenarios[0].fixtures.with_skills; return pack; })()],
+        ["missing without_skills fixture", (() => { const pack = buildValidPack(); delete pack.scenarios[0].fixtures.without_skills; return pack; })()]
+    ])("fails validation for %s", async (_label, invalidPack) => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        vi.mocked(yaml.load as any).mockReturnValue(invalidPack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+        expect(resolveCommandScope).not.toHaveBeenCalled();
+        expect(mockConfigManager.loadConfig).not.toHaveBeenCalled();
+    });
+
+    it("fails validation when minimum fixture fields are missing", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        delete pack.scenarios[0].fixtures.with_skills.trace_sequence;
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+    });
+
+    it("passes expect_assertion_improved delta assertion when with-skills improves", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        pack.scenarios[0].assertions.delta = { expect_assertion_improved: true };
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await voyagerAction(undefined, options, mockCommand);
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls.at(-1)[0]);
+        expect(jsonOutput.scenarios[0].delta.assertion_improved).toBe(true);
+    });
+
+    it("fails expect_assertion_improved delta assertion when there is no improvement", async () => {
+        const options = { file: "pack.yaml", format: "json" };
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+        const pack = buildValidPack();
+        pack.scenarios[0].fixtures.without_skills.status = "completed";
+        pack.scenarios[0].assertions.delta = { expect_assertion_improved: true };
+        vi.mocked(yaml.load as any).mockReturnValue(pack);
+
+        await expect(voyagerAction(undefined, options, mockCommand)).rejects.toThrow("exit");
+    });
+
+    it("passes and fails expect_status_changed delta assertions appropriately", async () => {
+        const passOptions = { file: "pack-pass.yaml", format: "json" };
+        const passCommand = { opts: vi.fn().mockReturnValue(passOptions) };
+        const passingPack = buildValidPack();
+        passingPack.scenarios[0].assertions.delta = { expect_status_changed: true };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(passingPack);
+        await voyagerAction(undefined, passOptions, passCommand);
+
+        const failOptions = { file: "pack-fail.yaml", format: "json" };
+        const failCommand = { opts: vi.fn().mockReturnValue(failOptions) };
+        const failingPack = buildValidPack();
+        failingPack.scenarios[0].fixtures.without_skills.status = "completed";
+        failingPack.scenarios[0].assertions.delta = { expect_status_changed: true };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(failingPack);
+        await expect(voyagerAction(undefined, failOptions, failCommand)).rejects.toThrow("exit");
+    });
+
+    it("passes and fails expect_status_summary delta assertions appropriately", async () => {
+        const passOptions = { file: "pack-pass.yaml", format: "json" };
+        const passCommand = { opts: vi.fn().mockReturnValue(passOptions) };
+        const passingPack = buildValidPack();
+        passingPack.scenarios[0].assertions.delta = { expect_status_summary: "failed -> completed" };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(passingPack);
+        await voyagerAction(undefined, passOptions, passCommand);
+
+        const failOptions = { file: "pack-fail.yaml", format: "json" };
+        const failCommand = { opts: vi.fn().mockReturnValue(failOptions) };
+        const failingPack = buildValidPack();
+        failingPack.scenarios[0].assertions.delta = { expect_status_summary: "completed -> completed" };
+        vi.mocked(yaml.load as any).mockReturnValueOnce(failingPack);
+        await expect(voyagerAction(undefined, failOptions, failCommand)).rejects.toThrow("exit");
+    });
+
+    it("enforces eq/gte/lte comparator assertions for each delta metric", async () => {
+        const comparatorCases = [
+            { label: "tool", field: "expect_tool_count_delta", pass: { eq: 1 }, fail: { eq: 2 } },
+            { label: "iteration", field: "expect_iteration_delta", pass: { gte: 1 }, fail: { lte: 0 } },
+            { label: "elapsed", field: "expect_elapsed_ms_delta", pass: { lte: 80 }, fail: { gte: 100 } }
+        ] as const;
+
+        for (const comparatorCase of comparatorCases) {
+            const passOptions = { file: `pack-pass-${comparatorCase.label}.yaml`, format: "json" };
+            const passCommand = { opts: vi.fn().mockReturnValue(passOptions) };
+            const passingPack = buildValidPack();
+            passingPack.scenarios[0].assertions.delta = { [comparatorCase.field]: comparatorCase.pass };
+            vi.mocked(yaml.load as any).mockReturnValueOnce(passingPack);
+            await voyagerAction(undefined, passOptions, passCommand);
+
+            const failOptions = { file: `pack-fail-${comparatorCase.label}.yaml`, format: "json" };
+            const failCommand = { opts: vi.fn().mockReturnValue(failOptions) };
+            const failingPack = buildValidPack();
+            failingPack.scenarios[0].assertions.delta = { [comparatorCase.field]: comparatorCase.fail };
+            vi.mocked(yaml.load as any).mockReturnValueOnce(failingPack);
+            await expect(voyagerAction(undefined, failOptions, failCommand)).rejects.toThrow("exit");
+        }
+    });
 });
+
+function buildValidPack() {
+    return {
+        kind: "harbor.voyager.benchmark-pack",
+        version: 1,
+        pack: {
+            id: "basic-pack",
+            name: "Basic Pack"
+        },
+        scenarios: [
+            {
+                id: "basic-pack-scenario",
+                name: "Basic Scenario",
+                query: "Check a workflow with and without skills.",
+                fixtures: {
+                    with_skills: makeOfflineFixture({
+                        status: "completed",
+                        final_answer: "done with skills",
+                        iterations: 2,
+                        elapsed_ms: 120,
+                        available_tool_count: 1,
+                        trace_sequence: ["ToolA"],
+                        trace: [
+                            { role: "system", content: "system" },
+                            { role: "user", content: "user" },
+                            { role: "assistant", content: "" },
+                            { role: "tool", toolName: "ToolA", content: "ok" },
+                            { role: "assistant", content: "done with skills" }
+                        ]
+                    }),
+                    without_skills: makeOfflineFixture({
+                        status: "failed",
+                        final_answer: "done without skills",
+                        iterations: 1,
+                        elapsed_ms: 40,
+                        available_tool_count: 0,
+                        trace_sequence: [],
+                        trace: [
+                            { role: "system", content: "system" },
+                            { role: "user", content: "user" },
+                            { role: "assistant", content: "done without skills" }
+                        ]
+                    })
+                },
+                assertions: {
+                    with_skills: {
+                        expected_tools: ["ToolA"],
+                        assert_final_contains: ["done"],
+                        assert_status: "completed"
+                    },
+                    without_skills: {
+                        assert_status: "failed"
+                    },
+                    delta: {
+                        expect_assertion_improved: true,
+                        expect_status_changed: true,
+                        expect_status_summary: "failed -> completed",
+                        expect_tool_count_delta: { eq: 1 },
+                        expect_iteration_delta: { eq: 1 },
+                        expect_elapsed_ms_delta: { eq: 80 }
+                    }
+                }
+            }
+        ]
+    } as any;
+}
+
+function makeOfflineFixture(overrides: any) {
+    return {
+        status: "completed",
+        final_answer: "done",
+        iterations: 1,
+        elapsed_ms: 10,
+        available_tool_count: 0,
+        trace_sequence: [],
+        trace: [
+            { role: "system", content: "system" },
+            { role: "user", content: "user" },
+            { role: "assistant", content: "done" }
+        ],
+        ...overrides
+    };
+}
 
 function makeFetchResponse(message: any) {
     return {

--- a/apps/cli/src/commands/voyager.ts
+++ b/apps/cli/src/commands/voyager.ts
@@ -17,7 +17,15 @@ import {
 } from "../services/ghosts";
 import {
     VoyagerAssertionSummary,
+    VoyagerBenchmarkPackDefinition,
+    VoyagerBenchmarkPackSummary,
+    VoyagerBenchmarkScenarioDefinition,
+    VoyagerBenchmarkScenarioSummary,
+    VoyagerBranchAssertions,
     VoyagerCompareResult,
+    VoyagerDeltaAssertions,
+    VoyagerDeltaComparator,
+    VoyagerOfflineFixtureResult,
     VoyagerRunResult,
     VoyagerTestDefinition,
     VoyagerTraceEvent
@@ -26,6 +34,16 @@ import { printError, printHeader, printSuccess } from "../ui";
 
 const DEFAULT_MOCK_RESPONSE = "Simulated success. Context payload acknowledged.";
 const MAX_ITERATIONS = 10;
+const BENCHMARK_PACK_KIND = "harbor.voyager.benchmark-pack";
+const BENCHMARK_PACK_RESULT_KIND = "harbor.voyager.benchmark-pack.result";
+const SCENARIO_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const OFFLINE_FIXTURE_STATUSES = new Set<VoyagerOfflineFixtureResult["status"]>([
+    "completed",
+    "assertion_failed",
+    "max_iterations",
+    "api_error",
+    "failed"
+]);
 
 type VoyagerTool = {
     type: "function";
@@ -46,6 +64,21 @@ type VoyagerConfig = {
     baseUrl: string;
 };
 
+type VoyagerInputDefinition =
+    | { kind: "legacy"; testDef: VoyagerTestDefinition }
+    | { kind: "benchmark-pack"; packDef: VoyagerBenchmarkPackDefinition; sourcePath: string };
+
+type VoyagerBenchmarkScenarioExecution = {
+    summary: VoyagerBenchmarkScenarioSummary;
+    withSkillsRun: VoyagerRunResult;
+    withoutSkillsRun: VoyagerRunResult;
+};
+
+type VoyagerBenchmarkPackExecution = {
+    summary: VoyagerBenchmarkPackSummary;
+    scenarioExecutions: VoyagerBenchmarkScenarioExecution[];
+};
+
 export async function voyagerAction(queryArg: string | undefined, options: any, command: any) {
     const opts = command.opts();
     const format = opts.format ?? "pretty";
@@ -58,7 +91,34 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
             printHeader("Voyager: Fleet Integration Testing");
         }
 
-        const testDef = await loadVoyagerTestDefinition(queryArg, opts);
+        const input = await loadVoyagerInputDefinition(queryArg, opts);
+        const traceDir = resolveTraceDirectory(opts.saveTrace, input.kind === "benchmark-pack" ? input.packDef.pack.id : undefined);
+
+        if (input.kind === "benchmark-pack") {
+            const result = await runVoyagerBenchmarkPack({
+                packDef: input.packDef,
+                sourcePath: input.sourcePath,
+                pretty,
+                spinnies
+            });
+
+            if (traceDir) {
+                await saveVoyagerPackArtifacts(traceDir, result);
+            }
+
+            if (format === "json") {
+                console.log(JSON.stringify(result.summary, null, 2));
+            } else {
+                printVoyagerBenchmarkPackResult(result.summary, traceDir);
+            }
+
+            if (!result.summary.pass) {
+                process.exit(1);
+            }
+            return;
+        }
+
+        const testDef = input.testDef;
         const manifestManager = getManifestManager({ global: false });
         const { useGlobalScope, shouldStop } = await resolveCommandScope({ global: false }, manifestManager, "skill-harbor voyager");
         if (shouldStop) return;
@@ -150,7 +210,6 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
 
             const result = buildVoyagerCompareResult(testDef, withSkills, withoutSkills);
 
-            const traceDir = resolveTraceDirectory(opts.saveTrace);
             if (traceDir) {
                 await saveVoyagerArtifacts(traceDir, result);
             }
@@ -181,7 +240,6 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
             run
         };
 
-        const traceDir = resolveTraceDirectory(opts.saveTrace);
         if (traceDir) {
             await saveVoyagerArtifacts(traceDir, singlePayload);
         }
@@ -216,26 +274,236 @@ export async function voyagerAction(queryArg: string | undefined, options: any, 
     }
 }
 
-async function loadVoyagerTestDefinition(queryArg: string | undefined, opts: any): Promise<VoyagerTestDefinition> {
-    let testDef: VoyagerTestDefinition = { query: queryArg || "" };
-
-    if (opts.file) {
-        const filePath = path.resolve(process.cwd(), opts.file);
-        try {
-            const fileContent = await fs.readFile(filePath, "utf-8");
-            testDef = yaml.load(fileContent) as VoyagerTestDefinition;
-        } catch (err: any) {
-            printError(`Failed to read test definition from ${opts.file}: ${err.message}`);
-            process.exit(1);
-        }
+async function loadVoyagerInputDefinition(queryArg: string | undefined, opts: any): Promise<VoyagerInputDefinition> {
+    if (!opts.file) {
+        const testDef: VoyagerTestDefinition = { query: queryArg || "" };
+        ensureLegacyTestDefinition(testDef);
+        return { kind: "legacy", testDef };
     }
 
+    const filePath = path.resolve(process.cwd(), opts.file);
+    try {
+        const fileContent = await fs.readFile(filePath, "utf-8");
+        const parsed = yaml.load(fileContent) as unknown;
+
+        if (looksLikeBenchmarkPack(parsed)) {
+            return {
+                kind: "benchmark-pack",
+                packDef: validateBenchmarkPackDefinition(parsed),
+                sourcePath: filePath
+            };
+        }
+
+        const testDef = parsed as VoyagerTestDefinition;
+        ensureLegacyTestDefinition(testDef);
+        return { kind: "legacy", testDef };
+    } catch (err: any) {
+        printError(`Failed to read test definition from ${opts.file}: ${err.message}`);
+        process.exit(1);
+    }
+}
+
+function ensureLegacyTestDefinition(testDef: VoyagerTestDefinition) {
     if (!testDef.query) {
         printError("You must provide either an inline [query] or a -f/--file definition with a 'query' field.");
         process.exit(1);
     }
+}
 
-    return testDef;
+function looksLikeBenchmarkPack(value: unknown): boolean {
+    return isRecord(value) && (
+        "kind" in value
+        || "version" in value
+        || "pack" in value
+        || "scenarios" in value
+    );
+}
+
+function validateBenchmarkPackDefinition(value: unknown): VoyagerBenchmarkPackDefinition {
+    if (!isRecord(value)) {
+        throw new Error("Benchmark pack root must be an object.");
+    }
+
+    if (value.kind === undefined) {
+        throw new Error("Benchmark pack is missing required 'kind'.");
+    }
+    if (value.kind !== BENCHMARK_PACK_KIND) {
+        throw new Error(`Unsupported benchmark pack kind '${String(value.kind)}'. Expected '${BENCHMARK_PACK_KIND}'.`);
+    }
+    if (value.version !== 1) {
+        throw new Error(`Unsupported benchmark pack version '${String(value.version)}'. Expected 1.`);
+    }
+    if (!isRecord(value.pack)) {
+        throw new Error("Benchmark pack is missing required 'pack' object.");
+    }
+
+    const packId = value.pack.id;
+    if (typeof packId !== "string" || !SCENARIO_ID_PATTERN.test(packId)) {
+        throw new Error("Benchmark pack requires a slug-valid 'pack.id'.");
+    }
+
+    if (!Array.isArray(value.scenarios) || value.scenarios.length === 0) {
+        throw new Error("Benchmark pack requires a non-empty 'scenarios' array.");
+    }
+
+    const seenScenarioIds = new Set<string>();
+    const scenarios = value.scenarios.map((scenario, index) => validateBenchmarkScenario(scenario, index, seenScenarioIds));
+
+    return {
+        kind: BENCHMARK_PACK_KIND,
+        version: 1,
+        pack: {
+            id: packId,
+            name: typeof value.pack.name === "string" ? value.pack.name : undefined,
+            description: typeof value.pack.description === "string" ? value.pack.description : undefined,
+            tags: Array.isArray(value.pack.tags) ? value.pack.tags.filter((tag): tag is string => typeof tag === "string") : undefined
+        },
+        scenarios
+    };
+}
+
+function validateBenchmarkScenario(value: unknown, index: number, seenScenarioIds: Set<string>): VoyagerBenchmarkScenarioDefinition {
+    if (!isRecord(value)) {
+        throw new Error(`Scenario at index ${index} must be an object.`);
+    }
+
+    if (typeof value.id !== "string" || !SCENARIO_ID_PATTERN.test(value.id)) {
+        throw new Error(`Scenario at index ${index} requires a slug-valid 'id'.`);
+    }
+    if (seenScenarioIds.has(value.id)) {
+        throw new Error(`Duplicate scenario id '${value.id}'.`);
+    }
+    seenScenarioIds.add(value.id);
+
+    if (typeof value.query !== "string" || value.query.length === 0) {
+        throw new Error(`Scenario '${value.id}' requires a non-empty 'query'.`);
+    }
+    if (!isRecord(value.fixtures)) {
+        throw new Error(`Scenario '${value.id}' requires a 'fixtures' object.`);
+    }
+    if (!isRecord(value.fixtures.with_skills)) {
+        throw new Error(`Scenario '${value.id}' is missing required 'fixtures.with_skills'.`);
+    }
+    if (!isRecord(value.fixtures.without_skills)) {
+        throw new Error(`Scenario '${value.id}' is missing required 'fixtures.without_skills'.`);
+    }
+
+    return {
+        id: value.id,
+        name: typeof value.name === "string" ? value.name : undefined,
+        query: value.query,
+        tags: Array.isArray(value.tags) ? value.tags.filter((tag): tag is string => typeof tag === "string") : undefined,
+        fixtures: {
+            with_skills: validateOfflineFixture(value.fixtures.with_skills, value.id, "with_skills"),
+            without_skills: validateOfflineFixture(value.fixtures.without_skills, value.id, "without_skills")
+        },
+        assertions: validateScenarioAssertions(value.assertions)
+    };
+}
+
+function validateScenarioAssertions(value: unknown): VoyagerBenchmarkScenarioDefinition["assertions"] | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Scenario assertions must be an object when provided.");
+    }
+
+    return {
+        with_skills: validateBranchAssertions(value.with_skills),
+        without_skills: validateBranchAssertions(value.without_skills),
+        delta: validateDeltaAssertions(value.delta)
+    };
+}
+
+function validateBranchAssertions(value: unknown): VoyagerBranchAssertions | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Scenario branch assertions must be an object when provided.");
+    }
+
+    return {
+        expected_tools: Array.isArray(value.expected_tools)
+            ? value.expected_tools.filter((entry): entry is string => typeof entry === "string")
+            : undefined,
+        assert_final_contains: Array.isArray(value.assert_final_contains)
+            ? value.assert_final_contains.filter((entry): entry is string => typeof entry === "string")
+            : undefined,
+        assert_status: value.assert_status === "completed" || value.assert_status === "failed"
+            ? value.assert_status
+            : undefined
+    };
+}
+
+function validateDeltaAssertions(value: unknown): VoyagerDeltaAssertions | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Scenario delta assertions must be an object when provided.");
+    }
+
+    return {
+        expect_assertion_improved: typeof value.expect_assertion_improved === "boolean" ? value.expect_assertion_improved : undefined,
+        expect_status_changed: typeof value.expect_status_changed === "boolean" ? value.expect_status_changed : undefined,
+        expect_status_summary: typeof value.expect_status_summary === "string" ? value.expect_status_summary : undefined,
+        expect_tool_count_delta: validateDeltaComparator(value.expect_tool_count_delta),
+        expect_iteration_delta: validateDeltaComparator(value.expect_iteration_delta),
+        expect_elapsed_ms_delta: validateDeltaComparator(value.expect_elapsed_ms_delta)
+    };
+}
+
+function validateDeltaComparator(value: unknown): VoyagerDeltaComparator | undefined {
+    if (value === undefined) return undefined;
+    if (!isRecord(value)) {
+        throw new Error("Delta comparator must be an object when provided.");
+    }
+
+    const comparator: VoyagerDeltaComparator = {};
+    if (typeof value.eq === "number") comparator.eq = value.eq;
+    if (typeof value.gte === "number") comparator.gte = value.gte;
+    if (typeof value.lte === "number") comparator.lte = value.lte;
+    return Object.keys(comparator).length > 0 ? comparator : undefined;
+}
+
+function validateOfflineFixture(value: unknown, scenarioId: string, label: "with_skills" | "without_skills"): VoyagerOfflineFixtureResult {
+    if (!isRecord(value)) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' must be an object.`);
+    }
+
+    if (typeof value.status !== "string" || !OFFLINE_FIXTURE_STATUSES.has(value.status as VoyagerOfflineFixtureResult["status"])) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires a valid 'status'.`);
+    }
+    if (typeof value.final_answer !== "string") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires 'final_answer'.`);
+    }
+    if (typeof value.iterations !== "number") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires numeric 'iterations'.`);
+    }
+    if (typeof value.elapsed_ms !== "number") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires numeric 'elapsed_ms'.`);
+    }
+    if (typeof value.available_tool_count !== "number") {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires numeric 'available_tool_count'.`);
+    }
+    if (!Array.isArray(value.trace_sequence) || !value.trace_sequence.every((entry: unknown) => typeof entry === "string")) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires string-array 'trace_sequence'.`);
+    }
+    if (!Array.isArray(value.trace) || !value.trace.every(isVoyagerOfflineTraceEvent)) {
+        throw new Error(`Scenario '${scenarioId}' fixture '${label}' requires valid 'trace' entries.`);
+    }
+
+    return {
+        status: value.status as VoyagerOfflineFixtureResult["status"],
+        final_answer: value.final_answer,
+        iterations: value.iterations,
+        elapsed_ms: value.elapsed_ms,
+        available_tool_count: value.available_tool_count,
+        trace_sequence: value.trace_sequence,
+        trace: value.trace,
+        error: typeof value.error === "string" ? value.error : undefined
+    };
+}
+
+function isVoyagerOfflineTraceEvent(value: unknown): boolean {
+    if (!isRecord(value)) return false;
+    return typeof value.role === "string" && typeof value.content === "string";
 }
 
 async function discoverVoyagerTools(activeBerths: Array<{ path: string }>, profiler: ProfilerService): Promise<VoyagerTool[]> {
@@ -453,40 +721,7 @@ async function runVoyagerScenario({
         break;
     }
 
-    const assertions = evaluateVoyagerAssertions(
-        {
-            label,
-            status,
-            finalAnswer,
-            iterations: iteration,
-            elapsedMs: Date.now() - startedAt,
-            availableToolCount: tools.length,
-            toolCallCount: traceSequence.length,
-            traceSequence,
-            trace,
-            assertions: {
-                allPassed: true,
-                missingExpectedTools: [],
-                missingFinalContains: []
-            },
-            error
-        },
-        testDef
-    );
-
-    if (status === "completed" && !assertions.allPassed) {
-        status = "assertion_failed";
-    }
-
-    if (pretty) {
-        if (status === "completed" || status === "assertion_failed") {
-            spinnies.succeed(spinnerId, { text: `${kleur.green(label)} run complete.` });
-        } else {
-            spinnies.fail(spinnerId, { text: `${kleur.red(label)} run failed.` });
-        }
-    }
-
-    return {
+    const assertions = evaluateVoyagerBranchAssertions(runSkeleton({
         label,
         status,
         finalAnswer,
@@ -496,20 +731,170 @@ async function runVoyagerScenario({
         toolCallCount: traceSequence.length,
         traceSequence,
         trace,
-        assertions,
         error
+    }), {
+        expected_tools: testDef.expected_tools,
+        assert_final_contains: testDef.assert_final_contains,
+        assert_status: testDef.assert_status
+    });
+
+    if (status === "completed" && !assertions.allPassed) {
+        status = "assertion_failed";
+    }
+
+    const run = runSkeleton({
+        label,
+        status,
+        finalAnswer,
+        iterations: iteration,
+        elapsedMs: Date.now() - startedAt,
+        availableToolCount: tools.length,
+        toolCallCount: traceSequence.length,
+        traceSequence,
+        trace,
+        error
+    }, assertions);
+
+    if (pretty) {
+        if (status === "completed" || status === "assertion_failed") {
+            spinnies.succeed(spinnerId, { text: `${kleur.green(label)} run complete.` });
+        } else {
+            spinnies.fail(spinnerId, { text: `${kleur.red(label)} run failed.` });
+        }
+    }
+
+    return run;
+}
+
+async function runVoyagerBenchmarkPack({
+    packDef,
+    sourcePath,
+    pretty,
+    spinnies
+}: {
+    packDef: VoyagerBenchmarkPackDefinition;
+    sourcePath: string;
+    pretty: boolean;
+    spinnies: Spinnies;
+}): Promise<VoyagerBenchmarkPackExecution> {
+    const spinnerId = `voyager-pack-${packDef.pack.id}`;
+    if (pretty) {
+        spinnies.add(spinnerId, { text: `Running benchmark pack ${kleur.bold(packDef.pack.id)}...` });
+    }
+
+    const scenarioExecutions: VoyagerBenchmarkScenarioExecution[] = [];
+
+    for (const scenario of packDef.scenarios) {
+        const withSkillsRun = buildOfflineRunFromFixture("with-skills", scenario.fixtures.with_skills);
+        const withoutSkillsRun = buildOfflineRunFromFixture("without-skills", scenario.fixtures.without_skills);
+
+        const withSkillsAssertions = evaluateVoyagerBranchAssertions(withSkillsRun, scenario.assertions?.with_skills);
+        const withoutSkillsAssertions = evaluateVoyagerBranchAssertions(withoutSkillsRun, scenario.assertions?.without_skills);
+
+        const finalWithSkillsRun = finalizeOfflineRun(withSkillsRun, withSkillsAssertions);
+        const finalWithoutSkillsRun = finalizeOfflineRun(withoutSkillsRun, withoutSkillsAssertions);
+        const delta = buildVoyagerPackDelta(finalWithSkillsRun, finalWithoutSkillsRun);
+        const deltaEvaluation = evaluateVoyagerDeltaAssertions(delta, scenario.assertions?.delta);
+        const scenarioFailures = collectScenarioFailures(withSkillsAssertions, withoutSkillsAssertions, deltaEvaluation.failures);
+        const scenarioPassed = withSkillsAssertions.allPassed && withoutSkillsAssertions.allPassed && deltaEvaluation.allPassed;
+
+        scenarioExecutions.push({
+            withSkillsRun: finalWithSkillsRun,
+            withoutSkillsRun: finalWithoutSkillsRun,
+            summary: {
+                id: scenario.id,
+                name: scenario.name,
+                path: path.join("scenarios", scenario.id, "summary.json"),
+                status: scenarioPassed ? "passed" : "failed",
+                with_skills: {
+                    status: toPackConditionStatus(finalWithSkillsRun.status),
+                    assertions_passed: withSkillsAssertions.allPassed,
+                    tool_call_count: finalWithSkillsRun.toolCallCount
+                },
+                without_skills: {
+                    status: toPackConditionStatus(finalWithoutSkillsRun.status),
+                    assertions_passed: withoutSkillsAssertions.allPassed,
+                    tool_call_count: finalWithoutSkillsRun.toolCallCount
+                },
+                delta: {
+                    ...delta,
+                    expectations_passed: deltaEvaluation.allPassed
+                },
+                failures: scenarioFailures
+            }
+        });
+    }
+
+    const summary = buildVoyagerBenchmarkPackSummary(packDef, sourcePath, scenarioExecutions);
+
+    if (pretty) {
+        if (summary.pass) {
+            spinnies.succeed(spinnerId, { text: `Benchmark pack ${kleur.green(packDef.pack.id)} complete.` });
+        } else {
+            spinnies.fail(spinnerId, { text: `Benchmark pack ${kleur.red(packDef.pack.id)} failed.` });
+        }
+    }
+
+    return {
+        summary,
+        scenarioExecutions
     };
 }
 
-function evaluateVoyagerAssertions(run: VoyagerRunResult, testDef: VoyagerTestDefinition): VoyagerAssertionSummary {
+function buildOfflineRunFromFixture(label: string, fixture: VoyagerOfflineFixtureResult): VoyagerRunResult {
+    const trace = fixture.trace.map((entry, index) => ({
+        role: entry.role,
+        content: entry.content,
+        toolName: entry.toolName,
+        toolCallId: entry.toolCallId,
+        timestamp: entry.timestamp ?? new Date(Date.now() + index).toISOString()
+    }));
+
+    return runSkeleton({
+        label,
+        status: fixture.status === "failed" ? "assertion_failed" : fixture.status,
+        finalAnswer: fixture.final_answer,
+        iterations: fixture.iterations,
+        elapsedMs: fixture.elapsed_ms,
+        availableToolCount: fixture.available_tool_count,
+        toolCallCount: fixture.trace_sequence.length,
+        traceSequence: [...fixture.trace_sequence],
+        trace,
+        error: fixture.error
+    });
+}
+
+function finalizeOfflineRun(run: VoyagerRunResult, assertions: VoyagerAssertionSummary): VoyagerRunResult {
+    const status = run.status === "completed" && !assertions.allPassed
+        ? "assertion_failed"
+        : run.status;
+
+    return runSkeleton({
+        ...run,
+        status
+    }, assertions);
+}
+
+function runSkeleton(run: Omit<VoyagerRunResult, "assertions">, assertions?: VoyagerAssertionSummary): VoyagerRunResult {
+    return {
+        ...run,
+        assertions: assertions ?? {
+            allPassed: true,
+            missingExpectedTools: [],
+            missingFinalContains: []
+        }
+    };
+}
+
+function evaluateVoyagerBranchAssertions(run: VoyagerRunResult, assertions?: VoyagerBranchAssertions): VoyagerAssertionSummary {
     const missingExpectedTools: string[] = [];
     const missingFinalContains: string[] = [];
 
     let expectedToolsPassed: boolean | undefined;
-    if (testDef.expected_tools && testDef.expected_tools.length > 0) {
+    if (assertions?.expected_tools && assertions.expected_tools.length > 0) {
         expectedToolsPassed = true;
         let traceIdx = 0;
-        for (const expected of testDef.expected_tools) {
+        for (const expected of assertions.expected_tools) {
             const foundIdx = run.traceSequence.indexOf(expected, traceIdx);
             if (foundIdx === -1) {
                 expectedToolsPassed = false;
@@ -521,9 +906,9 @@ function evaluateVoyagerAssertions(run: VoyagerRunResult, testDef: VoyagerTestDe
     }
 
     let finalContainsPassed: boolean | undefined;
-    if (testDef.assert_final_contains && testDef.assert_final_contains.length > 0) {
+    if (assertions?.assert_final_contains && assertions.assert_final_contains.length > 0) {
         finalContainsPassed = true;
-        for (const fragment of testDef.assert_final_contains) {
+        for (const fragment of assertions.assert_final_contains) {
             if (!run.finalAnswer.includes(fragment)) {
                 finalContainsPassed = false;
                 missingFinalContains.push(fragment);
@@ -532,9 +917,8 @@ function evaluateVoyagerAssertions(run: VoyagerRunResult, testDef: VoyagerTestDe
     }
 
     let statusPassed: boolean | undefined;
-    if (testDef.assert_status) {
-        const normalizedStatus = run.status === "completed" ? "completed" : "failed";
-        statusPassed = normalizedStatus === testDef.assert_status;
+    if (assertions?.assert_status) {
+        statusPassed = toPackConditionStatus(run.status) === assertions.assert_status;
     }
 
     const allPassed = [expectedToolsPassed, finalContainsPassed, statusPassed].every(value => value !== false);
@@ -562,16 +946,165 @@ function buildVoyagerCompareResult(
         },
         with_skills: withSkills,
         without_skills: withoutSkills,
-        delta: {
-            status_changed: withSkills.status !== withoutSkills.status,
-            status_summary: `${withoutSkills.status} -> ${withSkills.status}`,
-            assertion_improved: Number(withSkills.assertions.allPassed) > Number(withoutSkills.assertions.allPassed),
-            iteration_delta: withSkills.iterations - withoutSkills.iterations,
-            elapsed_ms_delta: withSkills.elapsedMs - withoutSkills.elapsedMs,
-            tool_count_delta: withSkills.toolCallCount - withoutSkills.toolCallCount,
-            skills_used_delta: withSkills.availableToolCount - withoutSkills.availableToolCount
-        }
+        delta: buildVoyagerCompareDelta(withSkills, withoutSkills)
     };
+}
+
+function buildVoyagerCompareDelta(withSkills: VoyagerRunResult, withoutSkills: VoyagerRunResult): VoyagerCompareResult["delta"] {
+    return {
+        status_changed: withSkills.status !== withoutSkills.status,
+        status_summary: `${withoutSkills.status} -> ${withSkills.status}`,
+        assertion_improved: Number(withSkills.assertions.allPassed) > Number(withoutSkills.assertions.allPassed),
+        iteration_delta: withSkills.iterations - withoutSkills.iterations,
+        elapsed_ms_delta: withSkills.elapsedMs - withoutSkills.elapsedMs,
+        tool_count_delta: withSkills.toolCallCount - withoutSkills.toolCallCount,
+        skills_used_delta: withSkills.availableToolCount - withoutSkills.availableToolCount
+    };
+}
+
+function buildVoyagerPackDelta(withSkills: VoyagerRunResult, withoutSkills: VoyagerRunResult): VoyagerCompareResult["delta"] {
+    const withSkillsStatus = toPackConditionStatus(withSkills.status);
+    const withoutSkillsStatus = toPackConditionStatus(withoutSkills.status);
+    const assertionImproved = Number(withSkills.assertions.allPassed) > Number(withoutSkills.assertions.allPassed)
+        || (withSkillsStatus === "completed" && withoutSkillsStatus === "failed");
+
+    return {
+        status_changed: withSkillsStatus !== withoutSkillsStatus,
+        status_summary: `${withoutSkillsStatus} -> ${withSkillsStatus}`,
+        assertion_improved: assertionImproved,
+        iteration_delta: withSkills.iterations - withoutSkills.iterations,
+        elapsed_ms_delta: withSkills.elapsedMs - withoutSkills.elapsedMs,
+        tool_count_delta: withSkills.toolCallCount - withoutSkills.toolCallCount,
+        skills_used_delta: withSkills.availableToolCount - withoutSkills.availableToolCount
+    };
+}
+
+function evaluateVoyagerDeltaAssertions(delta: VoyagerCompareResult["delta"], assertions?: VoyagerDeltaAssertions): { allPassed: boolean; failures: string[] } {
+    if (!assertions) {
+        return { allPassed: true, failures: [] };
+    }
+
+    const failures: string[] = [];
+
+    if (assertions.expect_assertion_improved !== undefined && delta.assertion_improved !== assertions.expect_assertion_improved) {
+        failures.push(`Expected assertion_improved=${assertions.expect_assertion_improved} but received ${delta.assertion_improved}.`);
+    }
+    if (assertions.expect_status_changed !== undefined && delta.status_changed !== assertions.expect_status_changed) {
+        failures.push(`Expected status_changed=${assertions.expect_status_changed} but received ${delta.status_changed}.`);
+    }
+    if (assertions.expect_status_summary !== undefined && delta.status_summary !== assertions.expect_status_summary) {
+        failures.push(`Expected status_summary='${assertions.expect_status_summary}' but received '${delta.status_summary}'.`);
+    }
+
+    evaluateComparatorFailures("tool_count_delta", delta.tool_count_delta, assertions.expect_tool_count_delta, failures);
+    evaluateComparatorFailures("iteration_delta", delta.iteration_delta, assertions.expect_iteration_delta, failures);
+    evaluateComparatorFailures("elapsed_ms_delta", delta.elapsed_ms_delta, assertions.expect_elapsed_ms_delta, failures);
+
+    return {
+        allPassed: failures.length === 0,
+        failures
+    };
+}
+
+function evaluateComparatorFailures(
+    label: string,
+    value: number,
+    comparator: VoyagerDeltaComparator | undefined,
+    failures: string[]
+) {
+    if (!comparator) return;
+    if (comparator.eq !== undefined && value !== comparator.eq) {
+        failures.push(`Expected ${label} == ${comparator.eq} but received ${value}.`);
+    }
+    if (comparator.gte !== undefined && value < comparator.gte) {
+        failures.push(`Expected ${label} >= ${comparator.gte} but received ${value}.`);
+    }
+    if (comparator.lte !== undefined && value > comparator.lte) {
+        failures.push(`Expected ${label} <= ${comparator.lte} but received ${value}.`);
+    }
+}
+
+function collectScenarioFailures(
+    withSkills: VoyagerAssertionSummary,
+    withoutSkills: VoyagerAssertionSummary,
+    deltaFailures: string[]
+): string[] {
+    const failures: string[] = [];
+
+    if (withSkills.expectedToolsPassed === false) {
+        failures.push(`with_skills missing expected tools: ${withSkills.missingExpectedTools.join(", ")}`);
+    }
+    if (withSkills.finalContainsPassed === false) {
+        failures.push(`with_skills missing output fragments: ${withSkills.missingFinalContains.join(", ")}`);
+    }
+    if (withSkills.statusPassed === false) {
+        failures.push("with_skills status assertion failed.");
+    }
+
+    if (withoutSkills.expectedToolsPassed === false) {
+        failures.push(`without_skills missing expected tools: ${withoutSkills.missingExpectedTools.join(", ")}`);
+    }
+    if (withoutSkills.finalContainsPassed === false) {
+        failures.push(`without_skills missing output fragments: ${withoutSkills.missingFinalContains.join(", ")}`);
+    }
+    if (withoutSkills.statusPassed === false) {
+        failures.push("without_skills status assertion failed.");
+    }
+
+    failures.push(...deltaFailures);
+    return failures;
+}
+
+function buildVoyagerBenchmarkPackSummary(
+    packDef: VoyagerBenchmarkPackDefinition,
+    sourcePath: string,
+    executions: VoyagerBenchmarkScenarioExecution[]
+): VoyagerBenchmarkPackSummary {
+    const scenariosPassed = executions.filter(execution => execution.summary.status === "passed").length;
+    const scenariosFailed = executions.length - scenariosPassed;
+
+    const conditionsPassed = executions.reduce((sum, execution) => {
+        return sum
+            + Number(execution.summary.with_skills.assertions_passed)
+            + Number(execution.summary.without_skills.assertions_passed);
+    }, 0);
+
+    const deltaImproved = executions.filter(execution => execution.summary.delta.assertion_improved).length;
+    const deltaNeutral = executions.filter(execution => isNeutralDelta(execution.summary.delta)).length;
+    const deltaRegressed = executions.length - deltaImproved - deltaNeutral;
+
+    return {
+        kind: BENCHMARK_PACK_RESULT_KIND,
+        version: 1,
+        pack: {
+            id: packDef.pack.id,
+            name: packDef.pack.name,
+            source: sourcePath,
+            mode: "offline-fixture",
+            generated_at: new Date().toISOString()
+        },
+        totals: {
+            scenarios_total: executions.length,
+            scenarios_passed: scenariosPassed,
+            scenarios_failed: scenariosFailed,
+            conditions_total: executions.length * 2,
+            conditions_passed: conditionsPassed,
+            conditions_failed: executions.length * 2 - conditionsPassed,
+            delta_improved: deltaImproved,
+            delta_neutral: deltaNeutral,
+            delta_regressed: deltaRegressed
+        },
+        pass: scenariosFailed === 0,
+        scenarios: executions.map(execution => execution.summary)
+    };
+}
+
+function isNeutralDelta(delta: VoyagerBenchmarkScenarioSummary["delta"]): boolean {
+    return !delta.assertion_improved
+        && !delta.status_changed
+        && delta.iteration_delta === 0
+        && delta.elapsed_ms_delta === 0
+        && delta.tool_count_delta === 0;
 }
 
 function printVoyagerSingleResult(run: VoyagerRunResult, traceDir?: string) {
@@ -617,6 +1150,28 @@ function printVoyagerCompareResult(result: VoyagerCompareResult, traceDir?: stri
     }
 }
 
+function printVoyagerBenchmarkPackResult(result: VoyagerBenchmarkPackSummary, traceDir?: string) {
+    console.log(kleur.bold("Benchmark Pack Summary"));
+    console.log(`${kleur.gray("Pack:")} ${kleur.white(result.pack.name || result.pack.id)}`);
+    console.log(`${kleur.gray("Pass:")} ${result.pass ? kleur.green("yes") : kleur.red("no")}`);
+    console.log(`${kleur.gray("Scenarios:")} ${result.totals.scenarios_passed}/${result.totals.scenarios_total} passed`);
+
+    for (const scenario of result.scenarios) {
+        console.log(`\n${kleur.bold(scenario.id)} ${scenario.status === "passed" ? kleur.green("passed") : kleur.red("failed")}`);
+        console.log(`  ${kleur.gray("Status delta:")} ${scenario.delta.status_summary}`);
+        console.log(`  ${kleur.gray("Assertion improved:")} ${scenario.delta.assertion_improved ? "yes" : "no"}`);
+        if (scenario.failures.length > 0) {
+            for (const failure of scenario.failures) {
+                console.log(`  ${kleur.red("✗")} ${failure}`);
+            }
+        }
+    }
+
+    if (traceDir) {
+        console.log(`\n${kleur.gray("Saved trace artifacts:")} ${kleur.cyan(traceDir)}`);
+    }
+}
+
 function printAssertionSummary(assertions: VoyagerAssertionSummary, indent = "") {
     if (assertions.expectedToolsPassed !== undefined) {
         if (assertions.expectedToolsPassed) {
@@ -639,7 +1194,7 @@ function printAssertionSummary(assertions: VoyagerAssertionSummary, indent = "")
     }
 }
 
-function resolveTraceDirectory(saveTrace?: string | boolean): string | undefined {
+function resolveTraceDirectory(saveTrace?: string | boolean, packId?: string): string | undefined {
     if (!saveTrace) return undefined;
 
     if (typeof saveTrace === "string") {
@@ -647,7 +1202,8 @@ function resolveTraceDirectory(saveTrace?: string | boolean): string | undefined
     }
 
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    return path.join(process.cwd(), ".harbor", "voyager-runs", stamp);
+    const suffix = packId ? `-${packId}` : "";
+    return path.join(process.cwd(), ".harbor", "voyager-runs", `${stamp}${suffix}`);
 }
 
 async function saveVoyagerArtifacts(traceDir: string, payload: unknown) {
@@ -665,8 +1221,25 @@ async function saveVoyagerArtifacts(traceDir: string, payload: unknown) {
     await fs.writeFile(path.join(traceDir, "summary.json"), JSON.stringify(payload, null, 2), "utf-8");
 }
 
+async function saveVoyagerPackArtifacts(traceDir: string, payload: VoyagerBenchmarkPackExecution) {
+    await fs.mkdir(traceDir, { recursive: true });
+    await fs.writeFile(path.join(traceDir, "summary.json"), JSON.stringify(payload.summary, null, 2), "utf-8");
+
+    for (const execution of payload.scenarioExecutions) {
+        const scenarioDir = path.join(traceDir, "scenarios", execution.summary.id);
+        await fs.mkdir(scenarioDir, { recursive: true });
+        await fs.writeFile(path.join(scenarioDir, "with-skills.json"), JSON.stringify(execution.withSkillsRun, null, 2), "utf-8");
+        await fs.writeFile(path.join(scenarioDir, "without-skills.json"), JSON.stringify(execution.withoutSkillsRun, null, 2), "utf-8");
+        await fs.writeFile(path.join(scenarioDir, "summary.json"), JSON.stringify(execution.summary, null, 2), "utf-8");
+    }
+}
+
 function isComparePayload(payload: unknown): payload is VoyagerCompareResult {
     return Boolean(payload && typeof payload === "object" && "with_skills" in payload && "without_skills" in payload);
+}
+
+function toPackConditionStatus(status: VoyagerRunResult["status"]): "completed" | "failed" {
+    return status === "completed" ? "completed" : "failed";
 }
 
 function createTraceEvent(
@@ -682,4 +1255,8 @@ function createTraceEvent(
         toolCallId,
         timestamp: new Date().toISOString()
     };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -17,14 +17,14 @@ import { readFileSync } from "fs";
 const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
 
 const program = new Command();
-const collectTargets = (value: string, previous: string[] = []) => {
+function collectTargets(value: string, previous: string[] = []): string[] {
     const targets = value
         .split(",")
         .map(target => target.trim())
         .filter(Boolean);
 
     return [...previous, ...targets];
-};
+}
 
 program
     .name("skill-harbor")
@@ -63,6 +63,7 @@ program
     .command("check")
     .description("Verifies that berthed skills have valid metadata and integrity.")
     .option("-g, --global", "Check global manifest skills")
+    .option("--strict", "Fail on missing or underspecified contracts in addition to malformed ones.")
     .action(checkAction);
 
 program
@@ -116,7 +117,7 @@ program
     .option("--max-tokens <number>", "Gate threshold: Maximum total tokens allowed.")
     .option("--max-bloat <percentage>", "Gate threshold: Maximum context bloat percentage (GPT-4o).")
     .option("--min-score <number>", "Gate threshold: Minimum average fleet wake score.")
-    .option("-c, --contracts", "Run semantic contract validation between skills to ensure I/O schema compatibility.")
+    .option("-c, --contracts", "Run strict/focused semantic contract auditing in addition to default contract health analysis.")
     .option("-g, --global", "Target the global manifest (~/.harbor).")
     .action(fathomAction);
 

--- a/apps/cli/src/manifest.test.ts
+++ b/apps/cli/src/manifest.test.ts
@@ -72,6 +72,54 @@ describe("ManifestManager", () => {
         expect(manager.getLocalPath()).toBe(path.join(workspaceDir, ".harbor", "harbor-manifest.overrides.json"));
     });
 
+    it("preserves relative manifest sources while exposing resolved runtime sources", async () => {
+        await fs.mkdir(path.join(workspaceDir, ".harbor"), { recursive: true });
+        await fs.writeFile(
+            path.join(workspaceDir, ".harbor", "harbor-manifest.json"),
+            JSON.stringify({
+                version: "1.0",
+                dependencies: {},
+                skills: {
+                    quartermaster: {
+                        name: "quartermaster",
+                        source: "./skills/quartermaster",
+                        localPath: ""
+                    }
+                }
+            }),
+            "utf-8"
+        );
+
+        const manager = new ManifestManager({ cwd: workspaceDir });
+        const manifest = await manager.readMerged();
+
+        expect(manifest.skills.quartermaster.source).toBe("./skills/quartermaster");
+        expect(manifest.skills.quartermaster.resolvedSource).toBe(path.join(workspaceDir, "skills", "quartermaster"));
+    });
+
+    it("does not write runtime-only resolved sources back to manifests", async () => {
+        const manager = new ManifestManager({ cwd: workspaceDir });
+        await manager.init();
+
+        await manager.write({
+            version: "1.0",
+            dependencies: {},
+            skills: {
+                quartermaster: {
+                    name: "quartermaster",
+                    source: "./skills/quartermaster",
+                    resolvedSource: path.join(workspaceDir, "skills", "quartermaster"),
+                    localPath: ""
+                }
+            }
+        } as any);
+
+        const written = JSON.parse(await fs.readFile(path.join(workspaceDir, ".harbor", "harbor-manifest.json"), "utf-8"));
+
+        expect(written.skills.quartermaster.source).toBe("./skills/quartermaster");
+        expect(written.skills.quartermaster.resolvedSource).toBeUndefined();
+    });
+
     it("migrates a legacy local manifest filename to the overrides manifest path", async () => {
         const legacyPath = path.join(workspaceDir, "harbor-manifest.local.json");
         const preferredPath = path.join(workspaceDir, ".harbor", "harbor-manifest.overrides.json");

--- a/apps/cli/src/manifest.ts
+++ b/apps/cli/src/manifest.ts
@@ -32,6 +32,7 @@ export interface SkillEntry {
     generated?: boolean; // Expanded runtime-only child marker
     managedBy?: string; // Expanded runtime-only parent collection name
     collectionRoot?: string; // Expanded runtime-only folder root
+    resolvedSource?: string; // Runtime-only absolute source used for sync without rewriting manifests
 }
 
 export interface HarborManifest {
@@ -283,16 +284,17 @@ export class ManifestManager {
             ...(localManifest.targets || [])
         ]);
 
-        // Normalize local paths relative to manifest location
+        // Resolve local paths relative to manifest location for runtime use without
+        // mutating the manifest source that should be written back to disk.
         for (const skill of Object.values(mergedSkills)) {
             if (skill.source.startsWith('.') || skill.source.startsWith('file://.')) {
                 let manifestDir = this.cwd;
                 if (skill.layer === "global") manifestDir = path.dirname(ManifestManager.getGlobalPath());
-                
+
                 const rawPath = skill.source.replace('file://', '');
                 const absolutePath = path.resolve(manifestDir, rawPath);
-                // Maintain file:// protocol if it was present
-                skill.source = skill.source.startsWith('file://') ? `file://${absolutePath}` : absolutePath;
+                // Maintain file:// protocol if it was present.
+                skill.resolvedSource = skill.source.startsWith('file://') ? `file://${absolutePath}` : absolutePath;
             }
         }
 
@@ -351,6 +353,7 @@ export class ManifestManager {
         if (cleanManifest.skills) {
             for (const skill of Object.values(cleanManifest.skills as Record<string, any>)) {
                 delete skill.layer;
+                delete skill.resolvedSource;
             }
         }
 

--- a/apps/cli/src/orchestrator.test.ts
+++ b/apps/cli/src/orchestrator.test.ts
@@ -62,6 +62,20 @@ describe('Orchestrator Unit Tests', () => {
         await expect(fs.access(path.join(cargoPath, '.claude'))).rejects.toThrow();
     });
 
+    it('should explain missing local source paths before attempting to moor cargo', async () => {
+        const missingSkillPath = path.join(tempDir, 'missing-local-skill');
+
+        await expect(orchestrator.moor(missingSkillPath)).rejects.toThrow(
+            `Local skill source not found: ${missingSkillPath}. Update this manifest entry or remove the stale docked skill.`
+        );
+    });
+
+    it('should reject unqualified remote sources before invoking skillfish', async () => {
+        await expect(orchestrator.moor('local')).rejects.toThrow(
+            'Invalid remote skill source "local". Use "owner/repo" or "owner/repo/path/to/skill" for GitHub sources; use "./", "../", "/", or "file://" for local sources.'
+        );
+    });
+
     it('should resolve helper binaries by walking up to the workspace root', async () => {
         const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-harbor-workspace-'));
         const nestedPackageRoot = path.join(workspaceRoot, 'apps', 'cli');
@@ -144,7 +158,7 @@ describe('Orchestrator Unit Tests', () => {
 
         await nestedOrchestrator.cleanup();
         await fs.rm(workspaceRoot, { recursive: true, force: true });
-    });
+    }, 15000);
 
     // We can also test the private exists method by calling getMetadata on a path
     // which delegates to exists internally, allowing us to hit that branch.

--- a/apps/cli/src/orchestrator.ts
+++ b/apps/cli/src/orchestrator.ts
@@ -2,19 +2,56 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
-import Spinnies from "spinnies";
 import kleur from "kleur";
+import type { ProgressReporter } from "./progress";
+
+function isExplicitLocalSource(source: string): boolean {
+    return source.startsWith("file://") || source.startsWith("/") || source.startsWith("./") || source.startsWith("../");
+}
+
+function resolveLocalSourcePath(source: string): string {
+    return path.resolve(process.cwd(), source.replace("file://", ""));
+}
+
+function parseRemoteSkillSource(source: string): { repo: string; skillName: string } {
+    const cleanSource = source
+        .trim()
+        .replace(/^https?:\/\/(www\.)?github\.com\//, "")
+        .replace(/\/$/, "");
+
+    const spaceParts = cleanSource.split(/\s+/).filter(Boolean);
+    let repo = "";
+    let skillName = "";
+
+    if (spaceParts.length > 1) {
+        repo = spaceParts[0];
+        skillName = spaceParts.slice(1).join("/");
+    } else {
+        const slashParts = cleanSource.split("/").filter(Boolean);
+        if (slashParts.length >= 2) {
+            repo = `${slashParts[0]}/${slashParts[1]}`;
+            skillName = slashParts.length > 2 ? slashParts.slice(2).join("/") : "";
+        }
+    }
+
+    const repoParts = repo.split("/");
+    if (repoParts.length !== 2 || repoParts.some(part => part.trim().length === 0)) {
+        throw new Error(`Invalid remote skill source "${source}". Use "owner/repo" or "owner/repo/path/to/skill" for GitHub sources; use "./", "../", "/", or "file://" for local sources.`);
+    }
+
+    return { repo, skillName };
+}
 
 export class Orchestrator {
     private tempDir: string;
     private debugMode: boolean;
-    private spinnies: Spinnies;
+    private spinnies: ProgressReporter;
     private skillName: string;
     private packageRoot: string;
 
     constructor(options: { 
         skillName: string, 
-        spinnies: Spinnies, 
+        spinnies: ProgressReporter,
         debug?: boolean,
         packageRoot?: string
     }) {
@@ -72,10 +109,15 @@ export class Orchestrator {
             // Create .claude directory so skillfish detects it as a project
             await fs.mkdir(path.join(this.tempDir, ".claude"), { recursive: true });
 
-            // Pass local paths directly if needed, otherwise parse skillfish owner/repo format
-            if (url.startsWith('file://') || url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) {
-                const localPath = url.replace('file://', '');
-                const localStats = await fs.stat(localPath);
+            // Pass explicit local paths directly, otherwise parse skillfish owner/repo format.
+            if (isExplicitLocalSource(url)) {
+                const localPath = resolveLocalSourcePath(url);
+                const localStats = await fs.stat(localPath).catch((error: any) => {
+                    if (error?.code === "ENOENT") {
+                        throw new Error(`Local skill source not found: ${localPath}. Update this manifest entry or remove the stale docked skill.`);
+                    }
+                    throw error;
+                });
                 const localCargoPath = path.join(this.tempDir, path.basename(localPath));
 
                 if (localStats.isDirectory()) {
@@ -89,23 +131,7 @@ export class Orchestrator {
                 return localCargoPath;
             }
 
-            // Handle full GitHub URLs by stripping protocol
-            let cleanUrl = url.replace(/^https?:\/\/(www\.)?github\.com\//, '');
-            
-            // Format for skillfish: 'owner/repo skillname'
-            let repo = cleanUrl;
-            let skillName = "";
-            const parts = cleanUrl.split(" ");
-            if (parts.length > 1) {
-                repo = parts[0];
-                skillName = parts[1];
-            } else {
-                const slashParts = cleanUrl.split("/");
-                if (slashParts.length >= 2) {
-                    repo = `${slashParts[0]}/${slashParts[1]}`;
-                    if (slashParts.length > 2) skillName = slashParts.slice(2).join("/");
-                }
-            }
+            const { repo, skillName } = parseRemoteSkillSource(url);
 
             const binPath = await this.resolveLocalBin("skillfish");
             const args = ["add", repo];

--- a/apps/cli/src/progress.test.ts
+++ b/apps/cli/src/progress.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { dedupeRawProgressReporter, ProgressReporter } from "./progress";
+
+function makeBaseReporter(): ProgressReporter {
+    return {
+        add: vi.fn(),
+        update: vi.fn(),
+        succeed: vi.fn(),
+        fail: vi.fn(),
+        pick: vi.fn(),
+        remove: vi.fn()
+    } as any;
+}
+
+describe("dedupeRawProgressReporter", () => {
+    it("emits only the changed spinner line instead of replaying all prior spinners", () => {
+        const chunks: string[] = [];
+        const reporter = dedupeRawProgressReporter(makeBaseReporter(), {
+            write(chunk: string) {
+                chunks.push(chunk);
+                return true;
+            }
+        } as any);
+
+        reporter.add("test-skill", { text: "[test-skill] Mooring skill from local..." });
+        reporter.add("quartermaster", { text: "[quartermaster] Mooring skill from ./skills/quartermaster..." });
+        reporter.update("quartermaster", { text: "[quartermaster] Local skill cargo successfully moored." });
+
+        expect(chunks).toEqual([
+            "- [test-skill] Mooring skill from local...\n",
+            "- [quartermaster] Mooring skill from ./skills/quartermaster...\n",
+            "- [quartermaster] Local skill cargo successfully moored.\n"
+        ]);
+    });
+
+    it("does not emit duplicate terminal status lines that only differ by ANSI styling", () => {
+        const chunks: string[] = [];
+        const reporter = dedupeRawProgressReporter(makeBaseReporter(), {
+            write(chunk: string) {
+                chunks.push(chunk);
+                return true;
+            }
+        } as any);
+
+        reporter.update("quartermaster", { text: "\x1b[32m[quartermaster] Successfully berthed.\x1b[39m" });
+        reporter.succeed("quartermaster", { text: "\x1b[1m\x1b[32m[quartermaster] Successfully berthed.\x1b[39m\x1b[22m" });
+
+        expect(chunks).toEqual([
+            "- \x1b[32m[quartermaster] Successfully berthed.\x1b[39m\n"
+        ]);
+    });
+});

--- a/apps/cli/src/progress.ts
+++ b/apps/cli/src/progress.ts
@@ -1,0 +1,78 @@
+import Spinnies from "spinnies";
+
+export type ProgressReporter = Pick<Spinnies, "add" | "update" | "succeed" | "fail" | "pick" | "remove">;
+
+type ProgressStatus = "spinning" | "succeed" | "fail" | "stopped";
+type ProgressRecord = Record<string, any> & { text: string; status: ProgressStatus };
+type ProgressStream = Pick<NodeJS.WriteStream, "write">;
+
+const ESCAPE_CHARACTER = String.fromCharCode(27);
+const ANSI_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+function visibleText(value: string): string {
+    return value.replace(ANSI_PATTERN, "");
+}
+
+export function dedupeRawProgressReporter(base: ProgressReporter, stream: ProgressStream = process.stderr): ProgressReporter {
+    const records = new Map<string, ProgressRecord>();
+    const lastVisibleLines = new Map<string, string>();
+
+    const emit = (name: string, options: Record<string, any> = {}, status: ProgressStatus = "spinning"): ProgressRecord => {
+        const previous = records.get(name);
+        const next: ProgressRecord = {
+            ...previous,
+            ...options,
+            text: options.text ?? previous?.text ?? name,
+            status
+        };
+
+        records.set(name, next);
+
+        const visible = visibleText(next.text);
+        if (lastVisibleLines.get(name) !== visible) {
+            stream.write(`- ${next.text}\n`);
+            lastVisibleLines.set(name, visible);
+        }
+
+        if (status === "succeed" || status === "fail" || status === "stopped") {
+            records.delete(name);
+        }
+
+        return next;
+    };
+
+    return {
+        ...base,
+        pick(name: string) {
+            return records.get(name) ?? null;
+        },
+        add(name: string, options: Record<string, any> = {}) {
+            return emit(name, options, "spinning");
+        },
+        update(name: string, options: Record<string, any> = {}) {
+            return emit(name, options, options.status ?? "spinning");
+        },
+        succeed(name: string, options: Record<string, any> = {}) {
+            return emit(name, options, "succeed");
+        },
+        fail(name: string, options: Record<string, any> = {}) {
+            return emit(name, options, "fail");
+        },
+        remove(name: string) {
+            const removed = records.get(name) ?? null;
+            records.delete(name);
+            lastVisibleLines.delete(name);
+            return removed as any;
+        }
+    };
+}
+
+export function createSyncProgressReporter(): ProgressReporter {
+    const spinnies = new Spinnies({ disableSpins: true }) as ProgressReporter & { spin?: boolean };
+
+    if (spinnies.spin === false) {
+        return dedupeRawProgressReporter(spinnies);
+    }
+
+    return spinnies;
+}

--- a/apps/cli/src/services/contracts.test.ts
+++ b/apps/cli/src/services/contracts.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { calculateContractCompatibility, parseAndValidateContracts } from "./contracts";
+
+describe("contracts helpers", () => {
+    it("parses valid frontmatter contracts", () => {
+        const result = parseAndValidateContracts({
+            contracts: {
+                requires: { input_text: "string" },
+                produces: { summary: "json" }
+            }
+        }, "");
+
+        expect(result.status).toBe("valid");
+        expect(result.requires.input_text).toBe("string");
+        expect(result.produces.summary).toBe("json");
+    });
+
+    it("parses valid markdown contracts", () => {
+        const result = parseAndValidateContracts({}, `## Requires\n- input_text: string\n\n## Produces\n- summary: json`);
+
+        expect(result.status).toBe("valid");
+        expect(result.requires.input_text).toBe("string");
+        expect(result.produces.summary).toBe("json");
+    });
+
+    it("marks contracts missing when no declarations exist", () => {
+        const result = parseAndValidateContracts({}, "# No contracts here");
+        expect(result.status).toBe("missing");
+        expect(result.missingStandard).toBe(true);
+    });
+
+    it("fails malformed markdown contracts", () => {
+        const result = parseAndValidateContracts({}, `## Requires\nthis is malformed`);
+        expect(result.status).toBe("invalid");
+        expect(result.errors[0]).toContain("Malformed contract entry");
+    });
+
+    it("fails unknown contract types", () => {
+        const result = parseAndValidateContracts({
+            contracts: {
+                produces: { summary: "structured-json-ish" }
+            }
+        }, "");
+        expect(result.status).toBe("invalid");
+        expect(result.errors[0]).toContain("unknown type");
+    });
+
+    it("treats underspecified types as warnings instead of invalid contracts", () => {
+        const result = parseAndValidateContracts({
+            contracts: {
+                requires: { input_text: "any" }
+            }
+        }, "");
+
+        expect(result.status).toBe("valid");
+        expect(result.warnings[0]).toContain("underspecified");
+    });
+
+    it("fails duplicate markdown entries", () => {
+        const result = parseAndValidateContracts({}, `## Produces\n- summary: json\n- summary: markdown`);
+        expect(result.status).toBe("invalid");
+        expect(result.errors[0]).toContain("Duplicate contract entry");
+    });
+
+    it("calculates compatibility warnings and mismatches", () => {
+        const compatibility = calculateContractCompatibility([
+            {
+                skillName: "producer",
+                contracts: parseAndValidateContracts({ contracts: { produces: { summary: "json" } } }, "")
+            },
+            {
+                skillName: "consumer",
+                contracts: parseAndValidateContracts({ contracts: { requires: { summary: "markdown" } } }, "")
+            },
+            {
+                skillName: "missing-contract",
+                contracts: parseAndValidateContracts({}, "")
+            }
+        ]);
+
+        expect(compatibility.warnings.some(warning => warning.includes("Not explicitly configured for chaining"))).toBe(true);
+        expect(compatibility.mismatches.some(mismatch => mismatch.includes("Type mismatch"))).toBe(true);
+    });
+});

--- a/apps/cli/src/services/contracts.ts
+++ b/apps/cli/src/services/contracts.ts
@@ -1,0 +1,253 @@
+export interface ParsedContracts {
+    requires: Record<string, string>;
+    produces: Record<string, string>;
+    missingStandard: boolean;
+    isValid: boolean;
+    status: "valid" | "missing" | "invalid";
+    errors: string[];
+    warnings: string[];
+}
+
+export interface ContractHeadersConfig {
+    requiresHeader: string;
+    producesHeader: string;
+}
+
+const DEFAULT_HEADERS: ContractHeadersConfig = {
+    requiresHeader: "Requires",
+    producesHeader: "Produces"
+};
+
+const VALID_TYPES = new Set([
+    "string",
+    "text",
+    "markdown",
+    "html",
+    "json",
+    "json array",
+    "object",
+    "array",
+    "string array",
+    "number",
+    "integer",
+    "boolean",
+    "path",
+    "file",
+    "url",
+    "id"
+]);
+
+const UNDERSPECIFIED_TYPES = new Set([
+    "",
+    "any",
+    "unknown",
+    "mixed",
+    "value",
+    "data",
+    "output",
+    "input"
+]);
+
+const FIELD_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function parseAndValidateContracts(
+    metadata: any,
+    content: string,
+    headers?: Partial<ContractHeadersConfig>
+): ParsedContracts {
+    const config = {
+        ...DEFAULT_HEADERS,
+        ...headers
+    };
+
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    let requires: Record<string, string> = {};
+    let produces: Record<string, string> = {};
+    let missingStandard = true;
+
+    if (metadata?.contracts !== undefined) {
+        missingStandard = false;
+        const frontmatterResult = parseFrontmatterContracts(metadata.contracts);
+        requires = frontmatterResult.requires;
+        produces = frontmatterResult.produces;
+        errors.push(...frontmatterResult.errors);
+    } else {
+        const requiresResult = parseMarkdownContractSection(content, config.requiresHeader);
+        const producesResult = parseMarkdownContractSection(content, config.producesHeader);
+        requires = requiresResult.entries;
+        produces = producesResult.entries;
+        errors.push(...requiresResult.errors, ...producesResult.errors);
+        missingStandard = !(requiresResult.found || producesResult.found);
+    }
+
+    if (!missingStandard) {
+        validateContractEntries(requires, "requires", errors, warnings);
+        validateContractEntries(produces, "produces", errors, warnings);
+    }
+
+    let status: ParsedContracts["status"] = "valid";
+    if (errors.length > 0) {
+        status = "invalid";
+    } else if (missingStandard) {
+        status = "missing";
+    }
+
+    return {
+        requires,
+        produces,
+        missingStandard,
+        isValid: status !== "invalid",
+        status,
+        errors,
+        warnings
+    };
+}
+
+export function calculateContractCompatibility(
+    contractsBySkill: Array<{ skillName: string; contracts: ParsedContracts }>
+) {
+    const globalProduces: Record<string, { type: string; skillName: string }[]> = {};
+    const globalRequires: { skillName: string; variableName: string; requiredType: string }[] = [];
+    const warnings: string[] = [];
+    const mismatches: string[] = [];
+
+    for (const item of contractsBySkill) {
+        const { skillName, contracts } = item;
+
+        if (contracts.status === "missing") {
+            warnings.push(`[${skillName}] ⚠️  Not explicitly configured for chaining.`);
+            continue;
+        }
+
+        if (contracts.status === "invalid") {
+            warnings.push(`[${skillName}] ⚠️  Invalid contract declaration: ${contracts.errors.join("; ")}`);
+            continue;
+        }
+
+        for (const [varName, type] of Object.entries(contracts.produces)) {
+            if (!globalProduces[varName]) globalProduces[varName] = [];
+            globalProduces[varName].push({ type, skillName });
+        }
+
+        for (const [varName, requiredType] of Object.entries(contracts.requires)) {
+            globalRequires.push({ skillName, variableName: varName, requiredType });
+        }
+    }
+
+    for (const req of globalRequires) {
+        const producers = globalProduces[req.variableName];
+        if (!producers || producers.length === 0) {
+            warnings.push(`[${req.skillName}] Requires '${req.variableName}', but no skill in the harbor produces it. (May be provided by prompt).`);
+            continue;
+        }
+
+        for (const producer of producers) {
+            if (normalizeContractType(producer.type) !== normalizeContractType(req.requiredType)) {
+                mismatches.push(`[${req.skillName}] Type mismatch for '${req.variableName}': ${req.skillName} requires '${req.requiredType}', but ${producer.skillName} produces '${producer.type}'.`);
+            }
+        }
+    }
+
+    return { warnings, mismatches };
+}
+
+function parseFrontmatterContracts(value: unknown) {
+    const errors: string[] = [];
+    const requires = parseContractObject(value, "requires", errors);
+    const produces = parseContractObject(value, "produces", errors);
+    return { requires, produces, errors };
+}
+
+function parseContractObject(value: unknown, key: "requires" | "produces", errors: string[]) {
+    if (!isRecord(value)) {
+        errors.push(`contracts.${key} must be declared on an object.`);
+        return {};
+    }
+
+    const section = value[key];
+    if (section === undefined) return {};
+    if (!isRecord(section)) {
+        errors.push(`contracts.${key} must be an object.`);
+        return {};
+    }
+
+    const result: Record<string, string> = {};
+    for (const [field, type] of Object.entries(section)) {
+        if (typeof type !== "string") {
+            errors.push(`contracts.${key}.${field} must be a string type.`);
+            continue;
+        }
+        if (result[field] !== undefined) {
+            errors.push(`contracts.${key}.${field} is declared more than once.`);
+            continue;
+        }
+        result[field] = type.trim();
+    }
+
+    return result;
+}
+
+function parseMarkdownContractSection(content: string, headerName: string) {
+    const result: Record<string, string> = {};
+    const errors: string[] = [];
+    const headerRegex = new RegExp(`##\\s+${headerName}\\s*\\n([\\s\\S]*?)(?:\\n##|$)`, "i");
+    const match = content.match(headerRegex);
+
+    if (!(match && match[1])) {
+        return { entries: result, errors, found: false };
+    }
+
+    const sectionContent = match[1]
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+
+    for (const line of sectionContent) {
+        const itemMatch = line.match(/^-+\s*`?([a-zA-Z0-9_-]+)`?:\s*(.+)$/);
+        if (!itemMatch) {
+            errors.push(`Malformed contract entry under '${headerName}': ${line}`);
+            continue;
+        }
+
+        const [, field, type] = itemMatch;
+        if (result[field] !== undefined) {
+            errors.push(`Duplicate contract entry '${field}' under '${headerName}'.`);
+            continue;
+        }
+        result[field] = type.trim();
+    }
+
+    return { entries: result, errors, found: true };
+}
+
+function validateContractEntries(
+    entries: Record<string, string>,
+    section: "requires" | "produces",
+    errors: string[],
+    warnings: string[]
+) {
+    for (const [field, type] of Object.entries(entries)) {
+        if (!FIELD_NAME_PATTERN.test(field)) {
+            errors.push(`contracts.${section}.${field} has an invalid field name.`);
+        }
+
+        const normalizedType = normalizeContractType(type);
+        if (UNDERSPECIFIED_TYPES.has(normalizedType)) {
+            warnings.push(`contracts.${section}.${field} is underspecified.`);
+            continue;
+        }
+
+        if (!VALID_TYPES.has(normalizedType)) {
+            errors.push(`contracts.${section}.${field} has unknown type '${type}'.`);
+        }
+    }
+}
+
+function normalizeContractType(value: string) {
+    return value.trim().toLowerCase();
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/cli/src/services/profiler.test.ts
+++ b/apps/cli/src/services/profiler.test.ts
@@ -143,5 +143,61 @@ description: No contracts here.
 
             expect(result.contracts?.missingStandard).toBe(true);
         });
+
+        it("should mark malformed frontmatter contracts as invalid", async () => {
+            const skillPath = "/fake/bad-frontmatter";
+            const skillMd = `---
+name: bad-frontmatter
+description: broken
+contracts:
+  requires: [
+---`;
+            vi.mocked(fs.readFile).mockResolvedValue(skillMd);
+            vi.mocked(fs.readdir).mockResolvedValue([]);
+
+            const result = await service.getContractValidation(skillPath);
+
+            expect(result?.status).toBe("invalid");
+            expect(result?.errors[0]).toContain("Failed to parse SKILL.md frontmatter");
+        });
+    });
+
+    describe("generateHealthReport", () => {
+        it("includes parser-level contract warnings and escalates them in strict mode", async () => {
+            vi.spyOn(service, "calculateDisplacement").mockResolvedValue({
+                tokens: 100,
+                shipClass: "Dinghy",
+                icon: "🛶",
+                cost: { gpt4o: 0.001, gpt4oMini: 0.0001 }
+            });
+            vi.spyOn(service, "calculateHeuristicConfidence").mockResolvedValue({
+                score: 7,
+                condition: "Calm Seas",
+                wakeSize: "Small",
+                skillType: "Agent Skill",
+                validation: { namePresent: true, descriptionPresent: true, isProperlyFormatted: true, errors: [] },
+                heuristics: {
+                    semanticVagueness: 0,
+                    negativeConstraints: 0,
+                    schemaStrictness: 0,
+                    tagDensity: 0,
+                    triggerClarity: 0
+                },
+                contracts: {
+                    missingStandard: false,
+                    requires: { input_text: "any" },
+                    produces: {},
+                    isValid: true,
+                    status: "valid",
+                    errors: [],
+                    warnings: ["contracts.requires.input_text is underspecified."]
+                }
+            });
+
+            const report = await service.generateHealthReport(["/fake/skill-a"], undefined, undefined, undefined, true);
+
+            expect(report.contractWarnings).toContain("[skill-a] contracts.requires.input_text is underspecified.");
+            expect(report.status.violations).toContain("[skill-a] contracts.requires.input_text is underspecified.");
+        });
     });
 });

--- a/apps/cli/src/services/profiler.ts
+++ b/apps/cli/src/services/profiler.ts
@@ -5,6 +5,7 @@ import glob from "fast-glob";
 import { getEncoding } from "js-tiktoken";
 import { FathomMetrics, ShipClass, WaterCondition, SkillType, HarborHealthReport, FathomThresholds } from "../types/profiler";
 import { ConfigManager, SonarConfig } from "./config";
+import { calculateContractCompatibility, parseAndValidateContracts } from "./contracts";
 
 export class ProfilerService {
     private readonly encoding = getEncoding("cl100k_base");
@@ -37,12 +38,11 @@ export class ProfilerService {
      * Confidence (Heuristic): Calculates trigger likelihood (1-10) based on local heuristics.
      */
     async calculateHeuristicConfidence(skillPath: string): Promise<FathomMetrics["heuristicConfidence"] & { heuristics: FathomMetrics["heuristics"], validation: FathomMetrics["validation"], contracts: FathomMetrics["contracts"] }> {
-        const { metadata, content } = await this.readSkillMetadata(skillPath);
+        const { metadata, content, parseError } = await this.readSkillMetadata(skillPath);
         const validation = this.validateMetadata(metadata);
         const skillType = await this.detectSkillType(skillPath, metadata);
 
-        const configManager = ConfigManager.getInstance();
-        const contracts = this.extractContracts(metadata, content, configManager);
+        const contracts = this.getContractsForMetadata(metadata, content, parseError);
 
         let result: { 
             score: number; 
@@ -72,6 +72,11 @@ export class ProfilerService {
             heuristics: result.heuristics,
             contracts
         };
+    }
+
+    async getContractValidation(skillPath: string): Promise<FathomMetrics["contracts"]> {
+        const { metadata, content, parseError } = await this.readSkillMetadata(skillPath);
+        return this.getContractsForMetadata(metadata, content, parseError);
     }
 
     /**
@@ -167,7 +172,7 @@ export class ProfilerService {
     /**
      * Generates a comprehensive health report by aggregating metrics from all discovered skills.
      */
-    async generateHealthReport(skillPaths: string[], thresholds?: FathomThresholds, query?: string, sonarConfig?: SonarConfig, validateContracts: boolean = false): Promise<HarborHealthReport> {
+    async generateHealthReport(skillPaths: string[], thresholds?: FathomThresholds, query?: string, sonarConfig?: SonarConfig, strictContracts: boolean = false): Promise<HarborHealthReport> {
         let totalTokens = 0;
         let totalScoreSum = 0;
         let totalSonarSum = 0;
@@ -184,10 +189,11 @@ export class ProfilerService {
             "Galleon": 0
         };
 
-        const globalProduces: Record<string, { type: string; skillName: string }[]> = {};
-        const globalRequires: { skillName: string; variableName: string; requiredType: string }[] = [];
+        const contractsBySkill: Array<{ skillName: string; contracts: NonNullable<FathomMetrics["contracts"]> }> = [];
         const contractWarnings: string[] = [];
         const contractMismatches: string[] = [];
+        let explicitContractsCount = 0;
+        const violations: string[] = [];
 
         for (const skillPath of skillPaths) {
             const skillName = path.basename(skillPath);
@@ -215,16 +221,23 @@ export class ProfilerService {
 
             shipDistribution[disp.shipClass]++;
 
-            if (validateContracts) {
-                if (heuristic.contracts?.missingStandard) {
-                    contractWarnings.push(`[${skillName}] ⚠️  Not explicitly configured for chaining.`);
-                } else if (heuristic.contracts) {
-                    for (const [varName, type] of Object.entries(heuristic.contracts.produces)) {
-                        if (!globalProduces[varName]) globalProduces[varName] = [];
-                        globalProduces[varName].push({ type, skillName });
+            if (heuristic.contracts) {
+                contractsBySkill.push({ skillName, contracts: heuristic.contracts });
+                if (!heuristic.contracts.missingStandard) {
+                    explicitContractsCount++;
+                }
+                if (heuristic.contracts.warnings.length > 0) {
+                    const parserWarnings = heuristic.contracts.warnings.map(warning => `[${skillName}] ${warning}`);
+                    contractWarnings.push(...parserWarnings);
+                    if (strictContracts) {
+                        violations.push(...parserWarnings);
                     }
-                    for (const [varName, requiredType] of Object.entries(heuristic.contracts.requires)) {
-                        globalRequires.push({ skillName, variableName: varName, requiredType });
+                }
+                if (heuristic.contracts.status === "invalid") {
+                    const invalidMessage = `[${skillName}] Invalid contract declaration: ${heuristic.contracts.errors.join("; ")}`;
+                    contractWarnings.push(invalidMessage);
+                    if (strictContracts) {
+                        violations.push(invalidMessage);
                     }
                 }
             }
@@ -240,7 +253,6 @@ export class ProfilerService {
             { model: "GPT-4o-mini", limit: 128000, percentage: (totalTokens / 128000) * 100 }
         ];
 
-        const violations: string[] = [];
         if (thresholds) {
             if (thresholds.maxTokens && totalTokens > thresholds.maxTokens) {
                 violations.push(`Total tokens (${totalTokens.toLocaleString()}) exceed threshold of ${thresholds.maxTokens.toLocaleString()}.`);
@@ -254,22 +266,16 @@ export class ProfilerService {
             }
         }
 
-        if (validateContracts) {
-            for (const req of globalRequires) {
-                const producers = globalProduces[req.variableName];
-                if (!producers || producers.length === 0) {
-                    contractWarnings.push(`[${req.skillName}] Requires '${req.variableName}', but no skill in the harbor produces it. (May be provided by prompt).`);
-                } else {
-                    for (const producer of producers) {
-                        if (producer.type.toLowerCase() !== req.requiredType.toLowerCase()) {
-                            const mismatchMsg = `[${req.skillName}] Type mismatch for '${req.variableName}': ${req.skillName} requires '${req.requiredType}', but ${producer.skillName} produces '${producer.type}'.`;
-                            contractMismatches.push(mismatchMsg);
-                            violations.push(mismatchMsg); // Fails CI/CD
-                        }
-                    }
-                }
+        const compatibility = calculateContractCompatibility(contractsBySkill);
+        contractWarnings.push(...compatibility.warnings);
+        contractMismatches.push(...compatibility.mismatches);
+
+        if (strictContracts) {
+            for (const warning of compatibility.warnings) {
+                violations.push(warning);
             }
         }
+        violations.push(...compatibility.mismatches);
 
         return {
             totalSkills: skillPaths.length,
@@ -288,7 +294,8 @@ export class ProfilerService {
                 violations
             },
             contractMismatches,
-            contractWarnings
+            contractWarnings,
+            contractCoverage: skillPaths.length > 0 ? (explicitContractsCount / skillPaths.length) * 100 : 0
         };
     }
 
@@ -478,59 +485,44 @@ export class ProfilerService {
         return Array.prototype.concat(...files);
     }
 
-    private extractContracts(metadata: any, content: string, config: ConfigManager): FathomMetrics["contracts"] {
+    private getContractsForMetadata(metadata: any, content: string, parseError?: string): FathomMetrics["contracts"] {
+        if (parseError) {
+            return {
+                missingStandard: false,
+                requires: {},
+                produces: {},
+                isValid: false,
+                status: "invalid",
+                errors: [parseError],
+                warnings: []
+            };
+        }
+
+        const configManager = ConfigManager.getInstance();
         let contractsConfig;
         try {
-            contractsConfig = config.getConfig().contracts;
+            contractsConfig = configManager.getConfig().contracts;
         } catch {
             contractsConfig = { requiresHeader: "Requires", producesHeader: "Produces" };
         }
-        const requiresHeader = contractsConfig?.requiresHeader || "Requires";
-        const producesHeader = contractsConfig?.producesHeader || "Produces";
 
-        let requires: Record<string, string> = {};
-        let produces: Record<string, string> = {};
-        let missingStandard = true;
-
-        // 1. Try YAML frontmatter first
-        if (metadata.contracts) {
-            missingStandard = false;
-            requires = metadata.contracts.requires || {};
-            produces = metadata.contracts.produces || {};
-            return { missingStandard, requires, produces };
-        }
-
-        // 2. Fallback to Markdown parsing
-        const parseSection = (headerName: string): Record<string, string> => {
-            const result: Record<string, string> = {};
-            const headerRegex = new RegExp(`##\\s+${headerName}\\s*\\n([\\s\\S]*?)(?:\\n##|$)`, 'i');
-            const match = content.match(headerRegex);
-            
-            if (match && match[1]) {
-                missingStandard = false;
-                const sectionContent = match[1];
-                
-                const itemRegex = /-\s*`?([a-zA-Z0-9_\-]+)`?:\s*(.+)/g;
-                let itemMatch;
-                while ((itemMatch = itemRegex.exec(sectionContent)) !== null) {
-                    result[itemMatch[1]] = itemMatch[2].trim();
-                }
-            }
-            return result;
-        };
-
-        requires = parseSection(requiresHeader);
-        produces = parseSection(producesHeader);
-
-        return { missingStandard, requires, produces };
+        return parseAndValidateContracts(metadata, content, contractsConfig);
     }
 
-    private async readSkillMetadata(skillPath: string): Promise<{ metadata: any, content: string }> {
+    private async readSkillMetadata(skillPath: string): Promise<{ metadata: any, content: string, parseError?: string }> {
         const skillFile = path.join(skillPath, "SKILL.md");
         try {
             const rawContent = await fs.readFile(skillFile, "utf-8");
-            const { data, content } = matter(rawContent);
-            return { metadata: data, content };
+            try {
+                const { data, content } = matter(rawContent);
+                return { metadata: data, content };
+            } catch (error: any) {
+                return {
+                    metadata: {},
+                    content: rawContent,
+                    parseError: `Failed to parse SKILL.md frontmatter: ${error.message}`
+                };
+            }
         } catch {
             return { metadata: {}, content: "" };
         }

--- a/apps/cli/src/types/profiler.ts
+++ b/apps/cli/src/types/profiler.ts
@@ -15,6 +15,10 @@ export interface ContractValidation {
     missingStandard: boolean;
     requires: Record<string, string>;
     produces: Record<string, string>;
+    isValid: boolean;
+    status: "valid" | "missing" | "invalid";
+    errors: string[];
+    warnings: string[];
 }
 
 export interface FathomMetrics {
@@ -85,6 +89,7 @@ export interface HarborHealthReport {
     };
     contractMismatches?: string[];
     contractWarnings?: string[];
+    contractCoverage?: number;
     fleetStatus?: {
         berthed: number;
         stowed: number;

--- a/apps/cli/src/types/voyager.ts
+++ b/apps/cli/src/types/voyager.ts
@@ -16,6 +16,27 @@ export interface VoyagerTestDefinition {
     assert_status?: "completed" | "failed";
 }
 
+export interface VoyagerBranchAssertions {
+    expected_tools?: string[];
+    assert_final_contains?: string[];
+    assert_status?: "completed" | "failed";
+}
+
+export interface VoyagerDeltaComparator {
+    eq?: number;
+    gte?: number;
+    lte?: number;
+}
+
+export interface VoyagerDeltaAssertions {
+    expect_assertion_improved?: boolean;
+    expect_status_changed?: boolean;
+    expect_status_summary?: string;
+    expect_tool_count_delta?: VoyagerDeltaComparator;
+    expect_iteration_delta?: VoyagerDeltaComparator;
+    expect_elapsed_ms_delta?: VoyagerDeltaComparator;
+}
+
 export type VoyagerRunStatus = "completed" | "assertion_failed" | "max_iterations" | "api_error";
 
 export interface VoyagerTraceEvent {
@@ -24,6 +45,27 @@ export interface VoyagerTraceEvent {
     toolName?: string;
     toolCallId?: string;
     timestamp: string;
+}
+
+export interface VoyagerOfflineTraceEvent {
+    role: VoyagerTraceEvent["role"];
+    content: string;
+    toolName?: string;
+    toolCallId?: string;
+    timestamp?: string;
+}
+
+export type VoyagerOfflineFixtureStatus = VoyagerRunStatus | "failed";
+
+export interface VoyagerOfflineFixtureResult {
+    status: VoyagerOfflineFixtureStatus;
+    final_answer: string;
+    iterations: number;
+    elapsed_ms: number;
+    available_tool_count: number;
+    trace_sequence: string[];
+    trace: VoyagerOfflineTraceEvent[];
+    error?: string;
 }
 
 export interface VoyagerAssertionSummary {
@@ -66,4 +108,78 @@ export interface VoyagerCompareResult {
         tool_count_delta: number;
         skills_used_delta: number;
     };
+}
+
+export interface VoyagerBenchmarkScenarioDefinition {
+    id: string;
+    name?: string;
+    query: string;
+    tags?: string[];
+    fixtures: {
+        with_skills: VoyagerOfflineFixtureResult;
+        without_skills: VoyagerOfflineFixtureResult;
+    };
+    assertions?: {
+        with_skills?: VoyagerBranchAssertions;
+        without_skills?: VoyagerBranchAssertions;
+        delta?: VoyagerDeltaAssertions;
+    };
+}
+
+export interface VoyagerBenchmarkPackDefinition {
+    kind: "harbor.voyager.benchmark-pack";
+    version: 1;
+    pack: {
+        id: string;
+        name?: string;
+        description?: string;
+        tags?: string[];
+    };
+    scenarios: VoyagerBenchmarkScenarioDefinition[];
+}
+
+export interface VoyagerBenchmarkScenarioSummary {
+    id: string;
+    name?: string;
+    path?: string;
+    status: "passed" | "failed";
+    with_skills: {
+        status: "completed" | "failed";
+        assertions_passed: boolean;
+        tool_call_count: number;
+    };
+    without_skills: {
+        status: "completed" | "failed";
+        assertions_passed: boolean;
+        tool_call_count: number;
+    };
+    delta: VoyagerCompareResult["delta"] & {
+        expectations_passed: boolean;
+    };
+    failures: string[];
+}
+
+export interface VoyagerBenchmarkPackSummary {
+    kind: "harbor.voyager.benchmark-pack.result";
+    version: 1;
+    pack: {
+        id: string;
+        name?: string;
+        source: string;
+        mode: "offline-fixture";
+        generated_at: string;
+    };
+    totals: {
+        scenarios_total: number;
+        scenarios_passed: number;
+        scenarios_failed: number;
+        conditions_total: number;
+        conditions_passed: number;
+        conditions_failed: number;
+        delta_improved: number;
+        delta_neutral: number;
+        delta_regressed: number;
+    };
+    pass: boolean;
+    scenarios: VoyagerBenchmarkScenarioSummary[];
 }

--- a/apps/cli/src/ui.ts
+++ b/apps/cli/src/ui.ts
@@ -103,6 +103,11 @@ export const printHarborHealthReport = (report: any, format: string = 'pretty') 
         }
     }
 
+    if (report.contractCoverage !== undefined) {
+        content += `${kleur.bold().magenta('🤝 Contract Coverage')}\n`;
+        content += `${report.contractCoverage.toFixed(1)}% of scanned skills declare explicit contracts\n\n`;
+    }
+
     if (report.contractMismatches || report.contractWarnings) {
         if ((report.contractMismatches && report.contractMismatches.length > 0) || (report.contractWarnings && report.contractWarnings.length > 0)) {
             content += `${kleur.bold().magenta('🤝 Contract Integrity')}\n`;

--- a/apps/manual/content/docs/contracts-validation.mdx
+++ b/apps/manual/content/docs/contracts-validation.mdx
@@ -1,0 +1,99 @@
+---
+title: Contracts & Validation
+description: How Skill Harbor treats contracts as part of default validation and fleet analysis
+---
+
+# Contracts & Validation
+
+Skill Harbor now treats **contracts** as a more native part of the product instead of a niche add-on hidden behind `fathom --contracts`.
+
+The command model is now clearer:
+
+- **`check`** = structural validity
+- **`fathom`** = analysis and predictive fleet risk
+- **`voyager`** = empirical scenario behavior
+
+## Why this matters
+
+Contracts are one of the most important building blocks for reliable skill composition.
+
+If a skill declares the wrong inputs or outputs, or uses invalid types, that is not just an analytics detail — it is part of whether the skill is structurally sound in the first place.
+
+## `skill-harbor check`
+
+`check` now validates contract structure by default.
+
+### Default behavior
+- validates metadata
+- validates contract parsing and structure
+- reports whether contracts are:
+  - valid
+  - missing
+  - invalid
+
+### Default severity
+- **invalid contracts** fail `check`
+- **missing contracts** warn by default
+- **underspecified contracts** warn by default
+
+### Strict mode
+Use `check --strict` when you want tighter enforcement.
+
+In strict mode:
+- missing contracts can fail
+- underspecified contracts can fail
+
+## `skill-harbor fathom`
+
+Fathom now includes contract health as part of normal analysis.
+
+### Default behavior
+- per-skill output can show contract health
+- report mode can show:
+  - contract coverage
+  - contract warnings
+  - contract mismatches
+
+### `fathom --contracts`
+This flag still exists, but it should be understood as a **stricter or more focused contract audit mode** rather than the only way to see contract health.
+
+## Example: frontmatter contracts
+
+```yaml
+---
+name: fetch-logs
+description: Fetches application logs from AWS Cloudwatch
+contracts:
+  requires:
+    aws_region: string
+    service_name: string
+  produces:
+    log_stream: json array
+---
+```
+
+## Example: markdown contracts
+
+```markdown
+## Requires
+- `project_root`: path
+- `target_file`: path
+
+## Produces
+- `refactor_log`: json
+- `new_component`: string
+```
+
+## Mental model
+
+A simple way to remember the split:
+
+- **check** tells you whether the skill is structurally valid
+- **fathom** tells you whether the fleet looks risky or healthy
+- **voyager** tells you whether the scenario actually works
+
+## Related docs
+
+- `/docs/skill-standards`
+- `/docs/foundations/fathom`
+- `/docs/reference/commands`

--- a/apps/manual/content/docs/index.mdx
+++ b/apps/manual/content/docs/index.mdx
@@ -9,6 +9,9 @@ Welcome to **Unmint** — a beautiful, customizable documentation system built w
   <Card title="Quick Start" icon="rocket" href="/docs/quickstart">
     Get up and running with Unmint in under 5 minutes.
   </Card>
+  <Card title="Contracts & Validation" icon="shield-check" href="/docs/contracts-validation">
+    Learn how Skill Harbor now treats contracts as a native part of validation through `check`, `check --strict`, and `fathom`.
+  </Card>
   <Card title="Components" icon="code" href="/docs/components">
     Explore all the MDX components available out of the box.
   </Card>

--- a/apps/manual/content/docs/meta.json
+++ b/apps/manual/content/docs/meta.json
@@ -4,6 +4,7 @@
     "index",
     "quickstart",
     "---Getting Started---",
+    "contracts-validation",
     "components",
     "theming",
     "---Guides---",

--- a/docs/benchmarking/meta.json
+++ b/docs/benchmarking/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Benchmarking",
+  "pages": [
+    "overview",
+    "voyager-vs-fathom"
+  ]
+}

--- a/docs/benchmarking/overview.mdx
+++ b/docs/benchmarking/overview.mdx
@@ -1,0 +1,114 @@
+---
+title: "Benchmarking Overview"
+description: "How Skill Harbor approaches benchmarking, evaluation, and what it contributes beyond raw benchmark execution."
+icon: "chart-line"
+---
+
+# 📊 Benchmarking in Skill Harbor
+
+Skill Harbor is **not** trying to become a public leaderboard or replace benchmark projects like SkillsBench.
+
+Instead, Skill Harbor treats benchmarking as an **operational capability** inside a team workflow:
+
+- define what should be evaluated
+- run those evaluations repeatably
+- keep the evaluated skill set governed and portable
+- use the results to improve what the team actually ships
+
+That is the core difference.
+
+## The basic idea
+
+A benchmark is only useful if it can survive contact with a real team:
+
+- the skill set must be known
+- the evaluated context must be reproducible
+- the results must be inspectable later
+- the benchmark should fit local development and CI, not only a research harness
+
+Skill Harbor's role is to make those conditions true.
+
+## What Skill Harbor brings
+
+### 1. Governed evaluation inputs
+
+Before you benchmark anything, you need to know **which skills are actually in play**.
+
+Skill Harbor gives you:
+- a manifest-driven source of truth
+- provenance for skill sources
+- consistent berthing across supported agent targets
+- fleet-level inspection and validation
+
+That means benchmarking is attached to a **known fleet**, not an ad hoc pile of prompt files.
+
+### 2. Reproducible scenario evaluation
+
+Skill Harbor's contribution is not merely “run a benchmark.”
+It is to make evaluation:
+
+- **local-first**
+- **CI-friendly**
+- **portable**
+- **artifact-producing**
+
+That is why Voyager now grows toward **Harbor-native benchmark packs** instead of depending immediately on an external task format.
+
+### 3. Clear separation between measurement and prediction
+
+Skill Harbor intentionally separates two different questions:
+
+1. **What happened on a scenario?**
+2. **What is this fleet likely to help or hurt?**
+
+Those belong to different surfaces:
+
+- **Voyager** answers the first question through scenario execution and result comparison.
+- **Fathom** answers the second question through heuristics, audits, token analysis, and routing-risk signals.
+
+See **[Voyager vs Fathom](/docs/benchmarking/voyager-vs-fathom)** for the boundary.
+
+## Why this matters
+
+Without that separation, benchmarking tools tend to become muddy:
+
+- evaluators start acting like heuristic linters
+- heuristic tools start claiming benchmark truth
+- teams lose confidence in what each command is actually telling them
+
+Skill Harbor tries to keep the model clean:
+
+- **Voyager = empirical scenario evaluation**
+- **Fathom = predictive audit and fleet analysis**
+- **Skill Harbor overall = the governed system that makes both useful in practice**
+
+## How this aligns with SkillsBench
+
+SkillsBench is a strong research and evaluation lens.
+Skill Harbor takes the lessons of that lens and makes them **operational**:
+
+- benchmark-style scenarios can be run locally
+- packs can be checked into a repo
+- teams can use CI to keep evaluation repeatable
+- evaluation can be tied back to the governed fleet they actually use
+
+So the goal is not “be SkillsBench inside Skill Harbor.”
+The goal is:
+
+> make benchmark-style learning actionable inside a real engineering workflow.
+
+## Current direction
+
+The current Benchmarking direction in Skill Harbor is:
+
+1. **Voyager compare mode** for with-skills vs without-skills uplift
+2. **Harbor-native benchmark packs** for deterministic local/CI scenario evaluation
+3. **Fathom usefulness heuristics** informed later by empirical evaluation data
+4. **SkillsBench interop later**, as an adapter problem rather than a foundation dependency
+
+## Related pages
+
+- **[Voyager vs Fathom](/docs/benchmarking/voyager-vs-fathom)**
+- **[Voyager](/docs/foundations/voyager)**
+- **[Fathom](/docs/foundations/fathom)**
+- **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**

--- a/docs/benchmarking/voyager-vs-fathom.mdx
+++ b/docs/benchmarking/voyager-vs-fathom.mdx
@@ -1,0 +1,119 @@
+---
+title: "Voyager vs Fathom"
+description: "The product boundary between empirical scenario evaluation and predictive fleet analysis."
+icon: "split"
+---
+
+# 🧭 Voyager vs Fathom
+
+One of the easiest ways to confuse Skill Harbor's evaluation story is to blur **Voyager** and **Fathom** together.
+
+They are related, but they do different jobs.
+
+## Short version
+
+- **Voyager** measures what happens in a scenario.
+- **Fathom** analyzes what is likely to help or hurt before or across those scenarios.
+
+That distinction should stay intact even when Voyager adds deterministic benchmark packs.
+
+## Voyager: empirical scenario evaluation
+
+Voyager is the place for questions like:
+
+- Did the skill-enabled path outperform the no-skills path?
+- Did the agent invoke the expected tools?
+- Did the scenario pass or fail?
+- What trace did the run produce?
+- Can this evaluation be reproduced in CI?
+
+So Voyager owns:
+- scenario execution
+- branch comparison
+- traces
+- assertions
+- pass/fail outcomes
+- benchmark-pack results
+
+## Fathom: predictive and audit analysis
+
+Fathom is the place for questions like:
+
+- Is this fleet too large or too noisy?
+- Are skills colliding semantically?
+- Is the routing surface too vague?
+- How much context bloat is this adding?
+- Which skills look risky or promising before deeper evaluation?
+
+So Fathom owns:
+- heuristics
+- token/context analysis
+- contract validation
+- routing-risk signals
+- fleet-wide reports
+- predictive usefulness guidance
+
+## Why benchmark packs still belong in Voyager
+
+It may feel surprising that **offline deterministic packs** are still a Voyager feature.
+
+But the important boundary is **not**:
+- online = Voyager
+- offline = Fathom
+
+The real boundary is:
+- **scenario outcomes = Voyager**
+- **predictive audit = Fathom**
+
+A deterministic benchmark pack still asks a Voyager question:
+
+> what happened in this scenario, and how did the with-skills branch compare to the without-skills branch?
+
+That is still empirical evaluation, even when the evaluation is fixture-driven and reproducible in CI.
+
+## How they should work together
+
+The intended flow is:
+
+1. **Govern the fleet with Skill Harbor**
+2. **Inspect and predict with Fathom**
+3. **Measure scenario outcomes with Voyager**
+4. **Feed what you learn back into fleet refinement**
+
+In other words:
+
+- **Fathom** helps you decide what looks worth evaluating or trimming.
+- **Voyager** tells you what the scenario evidence actually says.
+
+## A practical rule
+
+If a command produces:
+- scenario traces
+- branch outcomes
+- assertion results
+- uplift/regression evidence
+
+it belongs in **Voyager**.
+
+If a command produces:
+- heuristics
+- token/collision reports
+- probabilistic routing confidence
+- fleet-level recommendations
+
+it belongs in **Fathom**.
+
+## Non-goal of Voyager benchmark packs
+
+Voyager benchmark packs should **not** become:
+- fleet health scores
+- heuristic usefulness scores
+- predictive deployment recommendations
+
+Those belong in Fathom.
+
+## Related pages
+
+- **[Benchmarking Overview](/docs/benchmarking/overview)**
+- **[Voyager](/docs/foundations/voyager)**
+- **[Fathom](/docs/foundations/fathom)**

--- a/docs/foundations/fathom.mdx
+++ b/docs/foundations/fathom.mdx
@@ -61,16 +61,25 @@ Fathom can be used as a **Pull Request Gate** to prevent context exhaustion or q
 - **`--max-tokens <n>`**: Fail if total fleet tokens exceed limit.
 - **`--max-bloat <p>`**: Fail if GPT-4o context saturation exceeds percentage.
 - **`--min-score <s>`**: Fail if average fleet quality score falls below threshold.
-- **`--contracts`**: Fail if explicit upstream outputs do not match downstream input requirements.
+- **default contract health**: contract warnings, invalid declarations, and mismatch data are part of normal Fathom analysis.
+- **`--contracts`**: Run a stricter or more contract-focused audit mode during the migration period.
 - **`--format json`**: Output machine-parsable data for programmatic consumption.
 
 ---
 
 ## 🤝 Semantic Contracts (Chaining Validation)
 
-To prevent hallucinations when passing unstructured data between linked skills, Fathom includes a **Semantic Contract Validation** engine. By running `skill-harbor fathom --contracts`, Fathom globally inspects all your skills to ensure their input and output requirements align safely.
+To prevent hallucinations when passing unstructured data between linked skills, Fathom includes a **Semantic Contract Validation** engine.
 
-If any explicit type mismatch is found (e.g., Skill A produces `json`, but Skill B requires `string`), Fathom will aggressively reject the build (Exit Code 1).
+Contract health is now part of the normal Fathom model:
+
+- default output can show whether a skill's contracts are healthy, missing, or invalid
+- `--report` can surface fleet-level contract coverage, warnings, and mismatches
+- severe cross-skill mismatches can affect fleet health status
+
+Use `skill-harbor fathom --contracts` when you want a stricter or more focused contract audit during the migration period.
+
+If any explicit type mismatch is found (e.g., Skill A produces `json`, but Skill B requires `string`), Fathom can treat that as a hard fleet integrity problem.
 
 ---
 

--- a/docs/foundations/voyager.mdx
+++ b/docs/foundations/voyager.mdx
@@ -25,7 +25,7 @@ If Voyager discovers unmanaged local skills while preparing that fleet, it can a
 skill-harbor voyager -f harbor-voyager-test.yaml
 
 # Run an ad-hoc query simulation
-skill-harbor voyager --query "Check if the codebase is portable."
+skill-harbor voyager "Check if the codebase is portable."
 ```
 
 ---
@@ -53,6 +53,43 @@ mocks:
 - **`mocks`**: A mapping of tool names to their simulated return values. This prevents the agent from actually executing destructive commands during the test.
 
 ---
+
+
+## 🧪 Benchmark Packs
+
+Voyager now supports a **Harbor-native benchmark-pack** format for deterministic, fixture-driven scenario evaluation in local and CI environments. This complements the existing live single-scenario flow without replacing it.
+
+- **Legacy scenario files** remain the current single-test YAML shape (`query`, `expected_tools`, `mocks`, assertions).
+- **Benchmark-pack files** use a versioned Harbor-native root with `kind`, `version`, `pack`, and `scenarios`.
+- Pack execution is **offline and API-key-free** in v1: it evaluates scenario outcomes from fixtures rather than running the live provider loop.
+
+### Product boundary
+- **Voyager** owns empirical scenario evaluation: traces, branch outcomes, assertions, uplift/regression.
+- **Fathom** owns predictive and audit-style analysis: heuristics, token/context analysis, routing confidence, fleet recommendations.
+
+That means benchmark packs still belong in Voyager: they make **scenario evaluation reproducible**, but they do **not** compute Fathom-style usefulness heuristics.
+
+### Benchmark-pack example
+
+```yaml
+kind: harbor.voyager.benchmark-pack
+version: 1
+pack:
+  id: sample-benchmark-pack
+  name: Sample Voyager Benchmark Pack
+scenarios:
+  - id: tool-uplift
+    query: "Check if the codebase is portable and then generate a report on any hidden skills."
+    fixtures:
+      with_skills: ...
+      without_skills: ...
+    assertions:
+      with_skills: ...
+      without_skills: ...
+      delta: ...
+```
+
+Use a checked-in pack such as `harbor-voyager-benchmark-pack.yaml` to run deterministic benchmark-style evaluations in CI.
 
 ## 🛡️ Governance & CI/CD
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -34,6 +34,9 @@ Instead of manual skill installation or fragile global configurations, Skill Har
   <Card title="📏 Analysis + Verification" icon="chart-bar" href="/docs/foundations/fathom">
     `fathom` audits token load, contracts, and ghost skills. `voyager` simulates agent workflows. `check` validates berthed skill metadata.
   </Card>
+  <Card title="📊 Benchmarking" icon="chart-line" href="/docs/benchmarking/overview">
+    Learn how Skill Harbor approaches benchmarking: Voyager for empirical scenario evaluation, Fathom for predictive audit and fleet analysis, and Harbor as the operational layer connecting both.
+  </Card>
   <Card title="👻 Ghost Governance" icon="ghost" href="/docs/foundations/ghosts">
     Learn what Ghosts are, use the new `skill-harbor ghosts` workflow, and understand how ghost inspection relates to Fathom, Voyager, stowage, and managed sources.
   </Card>
@@ -137,6 +140,8 @@ Skill Harbor is built for the **Solo Captain** and the **Full Fleet Command**.
 
 ## ❓ Related FAQ
 
+- **[Benchmarking Overview](/docs/benchmarking/overview)**
+- **[Voyager vs Fathom](/docs/benchmarking/voyager-vs-fathom)**
 - **[How does Skill Harbor align with SkillsBench?](/docs/faq/skillsbench)**
 - **[Why Not Skills.sh?](/docs/faq/comparison)**
 - **[Why Not Agent Skill Harbor?](/docs/faq/agent-skill-harbor)**

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -4,6 +4,7 @@
     "quickstart",
     "skill-standards",
     "---",
+    "benchmarking",
     "foundations",
     "reference",
     "faq"

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -117,12 +117,24 @@ Primary ghost inspection workflow for unmanaged skills discovered in active bert
 ---
 
 ## `voyager`
-End-to-end integration testing suite for agent-skill loops.
+End-to-end integration testing suite for agent-skill loops and deterministic benchmark-pack evaluation.
+
+**Usage:**
+- `skill-harbor voyager [query]`
+- `skill-harbor voyager -f <path>`
 
 **Flags:**
-- `-f, --file <path>`: Provide a YAML test definition file containing mocks and assertions.
-- `--query <text>`: Run an ad-hoc query simulation.
-- `--model <name>`: Override the model used for the simulation.
+- `-f, --file <path>`: Provide either a legacy single-scenario YAML definition or a Harbor-native benchmark-pack file.
+- `-c, --compare`: Run the same legacy scenario with and without skills, then report the delta.
+- `--format <type>`: Output `pretty` or `json`.
+- `--save-trace [dir]`: Persist run artifacts. Pack runs write a top-level `summary.json` plus per-scenario artifacts.
+- `--model <name>`: Override the model used for live Voyager simulation.
+- `--baseUrl <url>`: Override the API base URL for live Voyager simulation.
+
+**Notes:**
+- Legacy single-scenario files and inline queries still use the live Voyager flow.
+- Benchmark-pack files are **fixture-driven and API-key-free** in v1, making them suitable for deterministic local/CI evaluation.
+- Direct SkillsBench ingestion is deferred; benchmark packs are Harbor-native.
 
 *For more details on integration testing, see the [Voyager Deep Dive](/docs/foundations/voyager).*
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -84,9 +84,13 @@ The skill intelligence and profiling engine. Measures token saturation, quality 
 - `--report`: Generates a high-level Harbor Health Report.
 - `--details`: Provides a deep heuristic breakdown for every skill.
 - `--query <text>`: Conducts a probabilistic **Sonar** audit using the configured LLM provider.
-- `--contracts`: Audits semantic I/O contract alignment between fleet members.
+- `--contracts`: Runs a stricter or more contract-focused semantic I/O audit mode during migration.
 - `--ghosts`: Scans agent folders for unregistered "Ghost" skills and offers to dock them.
 - `--scan-mode <mode>`: Ghost-only scan mode for `--ghosts`. `autodetect` is the default; `targets-only` uses the selected manifest's declared targets exactly.
+
+**Notes:**
+- Fathom now includes contract health in default output and report modes.
+- `--contracts` is now a stricter / more focused contract-audit surface rather than the only way to see contract health.
 
 *For more details on the science behind Fathom, see the [Fathom Deep Dive](/docs/foundations/fathom).*
 
@@ -155,6 +159,15 @@ Manage your agent's environment state.
 
 ## `check`
 Verifies that all berthed skills have valid metadata and are correctly indexed for agent discovery.
+
+**Flags:**
+- `-g, --global`: Check skills from the global manifest.
+- `--strict`: Escalate missing or underspecified contracts in addition to malformed ones.
+
+**Notes:**
+- `check` now validates contract structure by default as part of skill correctness.
+- Missing contracts are warnings by default.
+- Malformed or contradictory contract declarations fail the command.
 
 ---
 

--- a/docs/skill-standards.mdx
+++ b/docs/skill-standards.mdx
@@ -74,21 +74,29 @@ Use `## Requires` and `## Produces` headers with an unordered list of code-ticke
 
 ```markdown
 ## Requires
-- `project_root`: The absolute path to the React project.
-- `target_file`: The relative path to the file for refactoring.
+- `project_root`: path
+- `target_file`: path
 
 ## Produces
-- `refactor_log`: A JSON payload containing the before/after line numbers.
-- `new_component`: The optimized source code as a string.
+- `refactor_log`: json
+- `new_component`: string
 ```
 
 ### Validation Rules
 
-When `skill-harbor fathom --contracts` runs:
+Contracts now participate in the default command model like this:
 
-- **Missing Standards**: If no `contracts` frontmatter or `## Requires`/`## Produces` sections are found, the skill is marked with a warning.
+- **`skill-harbor check`** validates contract structure by default.
+- **`skill-harbor check --strict`** escalates missing or underspecified contracts more aggressively.
+- **`skill-harbor fathom`** surfaces contract health as part of normal fleet analysis.
+- **`skill-harbor fathom --contracts`** acts as a stricter / more focused contract-audit mode during the migration period.
+
+That means:
+
+- **Missing Standards**: If no `contracts` frontmatter or `## Requires`/`## Produces` sections are found, the skill is surfaced as a warning by default.
+- **Malformed Structure**: If contract sections are malformed or declared types are invalid, `check` should fail.
 - **Missing Inputs**: If a skill requires a variable that no other skill produces, Fathom raises a **Warning** (the input may come from the user prompt).
-- **Type Mismatches**: If Skill A produces `user_id` as `integer` but Skill B requires it as `string`, Fathom throws a **Hard Validation Error (Exit Code 1)**.
+- **Type Mismatches**: If Skill A produces `user_id` as `integer` but Skill B requires it as `string`, Fathom can treat that as a fleet health problem and fail report gating.
 
 ### Customization
 

--- a/harbor-voyager-benchmark-pack.yaml
+++ b/harbor-voyager-benchmark-pack.yaml
@@ -1,0 +1,76 @@
+kind: harbor.voyager.benchmark-pack
+version: 1
+pack:
+  id: sample-benchmark-pack
+  name: Sample Voyager Benchmark Pack
+  description: Deterministic benchmark-pack example for local and CI evaluation.
+  tags:
+    - voyager
+    - benchmark
+    - ci
+scenarios:
+  - id: tool-uplift
+    name: Tool Uplift Example
+    query: "Check if the codebase is portable and then generate a report on any hidden skills."
+    tags:
+      - uplift
+      - regression
+    fixtures:
+      with_skills:
+        status: completed
+        final_answer: "Portable issues found: none. Hidden skills report generated."
+        iterations: 2
+        elapsed_ms: 120
+        available_tool_count: 2
+        trace_sequence:
+          - Scryer
+          - Fathom
+        trace:
+          - role: system
+            content: "system"
+          - role: user
+            content: "Check portability and hidden skills."
+          - role: assistant
+            content: ""
+          - role: tool
+            toolName: Scryer
+            content: "Portable issues found: none."
+          - role: tool
+            toolName: Fathom
+            content: "Hidden skills report: 2 ghost skills found."
+          - role: assistant
+            content: "Portable issues found: none. Hidden skills report generated."
+      without_skills:
+        status: failed
+        final_answer: "I could not complete both checks."
+        iterations: 1
+        elapsed_ms: 40
+        available_tool_count: 0
+        trace_sequence: []
+        trace:
+          - role: system
+            content: "system"
+          - role: user
+            content: "Check portability and hidden skills."
+          - role: assistant
+            content: "I could not complete both checks."
+    assertions:
+      with_skills:
+        expected_tools:
+          - Scryer
+          - Fathom
+        assert_final_contains:
+          - Hidden skills report
+        assert_status: completed
+      without_skills:
+        assert_status: failed
+      delta:
+        expect_assertion_improved: true
+        expect_status_changed: true
+        expect_status_summary: "failed -> completed"
+        expect_tool_count_delta:
+          eq: 2
+        expect_iteration_delta:
+          eq: 1
+        expect_elapsed_ms_delta:
+          eq: 80


### PR DESCRIPTION
## Summary

This PR makes contracts feel native to Skill Harbor instead of an optional sidecar behind `fathom --contracts`.

### What changed
- moved structural contract validation into default `check`
- added `check --strict`
- made contract health visible in default `fathom` output and report mode
- kept `fathom --contracts` as a stricter / focused migration mode
- extracted shared contract parsing/validation logic
- kept Voyager’s role unchanged

### Documentation / manual updates
- updated the main docs:
  - `docs/skill-standards.mdx`
  - `docs/foundations/fathom.mdx`
  - `docs/reference/commands.mdx`
- updated the manual app:
  - added `apps/manual/content/docs/contracts-validation.mdx`
  - linked it from manual navigation and home content

## Commit groups
1. **CLI / validation behavior**
   - native contract validation in `check`
   - default contract health in `fathom`
   - shared contract parser/validator
   - regression coverage and changeset

2. **Manual app documentation**
   - dedicated manual page for contracts & validation
   - manual nav/home wiring for the new feature

## Why

Contracts are part of structural skill correctness, not just optional analysis.

This PR clarifies the product model:
- `check` = validity
- `fathom` = analysis / predictive fleet risk
- `voyager` = empirical behavior

## Verification

### CLI surface
- `cd apps/cli && npx vitest run src/services/contracts.test.ts src/services/profiler.test.ts src/commands/check.test.ts src/commands/fathom.test.ts`
- `cd apps/cli && npx tsc --noEmit`
- `cd apps/cli && npm run build`
- `cd apps/cli && npx oxlint src/index.ts src/commands/check.ts src/commands/fathom.ts src/services/contracts.ts src/services/profiler.ts src/commands/check.test.ts src/commands/fathom.test.ts src/services/contracts.test.ts src/services/profiler.test.ts`

### Manual app
- `cd apps/manual && npm test`
- `cd apps/manual && npm run build`

## Notes
- includes a changeset for `skill-harbor`
- does not change Voyager behavior
- does not add new dependencies
