### PR TITLE
Fix Fathom spinner hang

### DIFF
--- a/.changeset/quartermaster-mp62k4zs.md
+++ b/.changeset/quartermaster-mp62k4zs.md
@@ -1,0 +1,16 @@
+---
+"skill-harbor": patch
+---
+
+<!-- hero: Fathom Surfaces Cleanly -->
+
+Captain's Briefing: Fathom now finishes its voyage without leaving a spinner line moored to the terminal, and the harbor trims generated local files out of future diffs.
+
+## 🔧 Repaired Ships
+- Fixed `fathomAction` in `apps/cli/src/commands/fathom.ts` so each per-skill spinner removal also stops the `Spinnies` manager, preventing the command from appearing to hang after the report finishes.
+- Added regression coverage in `apps/cli/src/commands/fathom.test.ts` to assert Fathom stops the spinner manager after removing an individual skill spinner.
+
+## 🛠️ Barnacle Scraping
+- Stopped tracking generated Next.js `next-env.d.ts` files and added `**/next-env.d.ts` to `.gitignore`, preventing dev/build route-type churn in `apps/manual` and future Next apps.
+- Added `.harbor/harbor-manifest.overrides.json` as an explicit empty override layer so Harbor tooling can distinguish intentional override defaults from a missing file.
+- Grouped local agent, release, and generated-source ignore rules in `.gitignore`, including `.codex/`, `.omx/`, `.unmint`, and Harbor stowage artifacts.

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,30 @@
 node_modules
 dist
 tsconfig.tsbuildinfo
+# OS
 .DS_Store
+
+# Agent folders and files
 .agent/skills/
 .claude/
 .cursor/
+.codex/
+.omx/
 .harbor/skills/
 .harbor/ghosts.json
 .harbor/stowage/
-.env*
-.npmrc
-*.tgz
-.harbor/harbor-manifest.overrides.json
+harbor-manifest.local.json
 harbor-compass.yaml
 *voyage-test.yaml
+
+# Environment variables
+.env*
+
+# NPM configuration
+.npmrc
+
+# Release files
+*.tgz
 
 # Turborepo
 .turbo
@@ -21,8 +32,8 @@ harbor-compass.yaml
 # Next.js
 .next
 out
+**/next-env.d.ts
 
-# Unmint
+# Source files
 .unmint
 .source
-.omx/

--- a/.harbor/harbor-manifest.overrides.json
+++ b/.harbor/harbor-manifest.overrides.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "dependencies": {},
+  "skills": {}
+}

--- a/apps/cli/src/commands/fathom.test.ts
+++ b/apps/cli/src/commands/fathom.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../services/ghosts";
 import { printHarborHealthReport, printHeader, printInfo } from "../ui";
 
+const spinniesInstances = vi.hoisted(() => [] as any[]);
+
 vi.mock("../command-scope");
 vi.mock("../utils");
 vi.mock("../services/config");
@@ -22,11 +24,16 @@ vi.mock("../ui");
 vi.mock("node:os");
 vi.mock("spinnies", () => ({
     default: class MockSpinnies {
+        constructor() {
+            spinniesInstances.push(this);
+        }
+
         add = vi.fn();
         update = vi.fn();
         fail = vi.fn();
         succeed = vi.fn();
         remove = vi.fn();
+        stopAll = vi.fn();
     }
 }));
 
@@ -42,6 +49,7 @@ describe("fathomAction", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        spinniesInstances.length = 0;
         Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
         Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
 
@@ -289,6 +297,46 @@ describe("fathomAction", () => {
         expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("✓ [skill1]"));
         expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("<Agent Skill>"));
         logSpy.mockRestore();
+    });
+
+    it("stops the spinner manager after removing an individual fathom spinner", async () => {
+        const options = {};
+        const mockCommand = { opts: vi.fn().mockReturnValue(options) };
+
+        mockManifestManager.readMerged.mockResolvedValue({
+            skills: {
+                skill1: { name: "skill1", source: "source1", layer: "shared" }
+            }
+        });
+        mockManifestManager.materializeSkills.mockReturnValue([{ name: "skill1", layer: "shared" }]);
+        (exists as any).mockImplementation(async (candidatePath: string) => (
+            candidatePath === "/harbor/skill1"
+        ));
+        mockProfiler.calculateDisplacement.mockResolvedValue({
+            icon: "🛳️",
+            shipClass: "Frigate",
+            tokens: 5001,
+            cost: { gpt4o: 0.025, gpt4oMini: 0.00075 }
+        });
+        mockProfiler.calculateHeuristicConfidence.mockResolvedValue({
+            score: 10,
+            condition: "Glassy Water",
+            skillType: "Agent Skill",
+            validation: { isProperlyFormatted: true, errors: [] },
+            heuristics: {
+                semanticVagueness: -1,
+                negativeConstraints: 0,
+                tagDensity: -2,
+                triggerClarity: -1
+            },
+            contracts: null
+        });
+
+        await fathomAction(options, mockCommand);
+
+        const spinniesInstance = spinniesInstances.at(-1);
+        expect(spinniesInstance.remove).toHaveBeenCalledWith("fathom-skill1");
+        expect(spinniesInstance.stopAll).toHaveBeenCalled();
     });
 
     it("shows API Tool in the default line and explains the type in details mode", async () => {

--- a/apps/cli/src/commands/fathom.ts
+++ b/apps/cli/src/commands/fathom.ts
@@ -35,6 +35,11 @@ function formatStatusEntries(entries: BerthDetail[]): string {
     return entries.map(formatBerthDetail).join(", ");
 }
 
+function removeSpinner(spinnies: Spinnies, name: string): void {
+    spinnies.remove(name);
+    spinnies.stopAll();
+}
+
 export async function fathomAction(options: any, command: any) {
     const opts = command.opts();
     const manifestManager = getManifestManager(opts);
@@ -253,7 +258,7 @@ export async function fathomAction(options: any, command: any) {
                     }
                 }
 
-                spinnies.remove(`fathom-${skill.name}`);
+                removeSpinner(spinnies, `fathom-${skill.name}`);
 
                 const costGpt4 = displacement.cost.gpt4o.toFixed(4);
                 const costMini = displacement.cost.gpt4oMini.toFixed(6);

--- a/apps/manual/next-env.d.ts
+++ b/apps/manual/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- stop Fathom spinner handles after per-skill analysis so the command exits cleanly
- stop tracking generated Next next-env.d.ts files and keep local agent artifacts ignored
- add default Harbor manifest override metadata

## Verification
- bun --cwd apps/cli test src/commands/fathom.test.ts
- bun run test
- bun run build
- cd apps/cli && bun run lint
- TTY watchdog reproduction exits cleanly for fathom